### PR TITLE
Fix transitive llvmlite dependency on MacOS x86_64

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,7 @@ on:
   push:
 
 jobs:
-  test:
+  test-linux:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -29,17 +29,34 @@ jobs:
        PGUSER: postgres
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up uv
-      # Install a specific uv version using the installer
-      run: curl -LsSf https://astral.sh/uv/0.4.1/install.sh | sh
+      uses: astral-sh/setup-uv@v5
 
     - name: Test with pytest
-      run: uv run --extra dev --extra indirect --resolution ${{ matrix.resolution }} --python ${{ matrix.python-version}} pytest --cov=volara tests
+      run: uv run --extra dev --extra indirect --resolution ${{ matrix.resolution }} --python ${{ matrix.python-version }} pytest --cov=volara tests
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
+
+  test-macos:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-15-intel]
+        python-version: ["3.12"]
+        resolution: ["highest"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Test with pytest
+      run: uv run --extra dev --extra indirect --resolution ${{ matrix.resolution }} --python ${{ matrix.python-version }} pytest --cov=volara tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "mwatershed>=0.5.2",
     "pydantic>=2.6.3",
     "numba>=0.59.0",
+    # llvmlite (numba dep) dropped macOS x86_64 wheels after 0.45; avoid source builds
+    "llvmlite<0.46,!=0.44.*; platform_machine == 'x86_64' and sys_platform == 'darwin'",
     "scipy>=1.15.3",
     "scikit-image>=0.25.2",
     "cloud-volume>=12.4.1",


### PR DESCRIPTION
llvmlite no longer builds pypi wheels for this platform. Its source
build process is broken with modern setuptools and LLVM, such that
building with, e.g. uv, is an involved process requiring an old LLVM and
custom build environment. Rather than force that or a conda install,
exclude those llvmlite versions.

Add GHA tests for MacOS intel and ARM.

While this isn't necessarily volara's problem, it is the proximate dependency in E11's python infrastructure. This makes it the best place to ensure our tools have a reasonable pypi install experience for devs for adoption, outreach, and onboarding.