### PR TITLE
add a few extra flags and features to lambda task.

### DIFF
--- a/tests/test_lambda_task.py
+++ b/tests/test_lambda_task.py
@@ -226,3 +226,135 @@ def test_lambda_task_properties(zarr_2d, tmp_path):
     assert task.write_size == Coordinate(5, 5)
     assert task.output_datasets == [out_data]
     assert task.write_roi == Raw(store=raw_path).array("r").roi
+
+
+def test_lambda_task_init_out_false_skips_prepare_and_drop(tmp_path):
+    """With init_out=False, init() does not create out_data and drop_artifacts() is a no-op.
+
+    pytest tests/test_lambda_task.py::test_lambda_task_init_out_false_skips_prepare_and_drop
+    """
+    data = np.random.default_rng(0).random((10, 10), dtype=np.float32)
+    in_path = tmp_path / "data.zarr" / "raw"
+    prepare_ds(
+        in_path,
+        shape=data.shape,
+        voxel_size=Coordinate(1, 1),
+        dtype=data.dtype,
+        mode="w",
+    )[:] = data
+
+    # Pre-create the output dataset (simulating an already-existing volume)
+    out_path = tmp_path / "data.zarr" / "out"
+    out_data_arr = prepare_ds(
+        out_path,
+        shape=(20, 20),
+        voxel_size=Coordinate(1, 1),
+        dtype=np.uint8,
+        mode="w",
+    )
+    out_data_arr[:] = 0
+
+    task = LambdaTask(
+        in_data=Raw(store=in_path),
+        out_data=Labels(store=out_path),
+        init_out=False,
+        lambda_func=lambda x: (x > 0.5).astype(np.uint8),
+        block_size=Coordinate(10, 10),
+    )
+
+    # init() should not recreate or overwrite the output
+    task.init()
+    result_shape = task.out_data.array("r").shape
+    assert result_shape == (20, 20), "init_out=False should not recreate the output array"
+
+    # drop_artifacts() should not remove the output
+    task.drop_artifacts()
+    assert out_path.exists(), "init_out=False should not drop the output array"
+
+
+def test_lambda_task_default_block_size_from_out_data(tmp_path):
+    """When block_size is None, write_size defaults to out_data's chunk shape.
+
+    pytest tests/test_lambda_task.py::test_lambda_task_default_block_size_from_out_data
+    """
+    data = np.random.default_rng(0).random((20, 20), dtype=np.float32)
+    in_path = tmp_path / "data.zarr" / "raw"
+    prepare_ds(
+        in_path,
+        shape=data.shape,
+        voxel_size=Coordinate(1, 1),
+        dtype=data.dtype,
+        mode="w",
+    )[:] = data
+
+    # Create output with a specific chunk shape (5, 5)
+    out_path = tmp_path / "data.zarr" / "out"
+    prepare_ds(
+        out_path,
+        shape=(20, 20),
+        voxel_size=Coordinate(1, 1),
+        dtype=np.uint8,
+        chunk_shape=Coordinate(5, 5),
+        mode="w",
+    )
+
+    task = LambdaTask(
+        in_data=Raw(store=in_path),
+        out_data=Labels(store=out_path),
+        init_out=False,
+        lambda_func=lambda x: (x > 0.5).astype(np.uint8),
+        # block_size intentionally omitted
+    )
+
+    # write_size should be chunk_shape * voxel_size = (5, 5) * (1, 1) = (5, 5)
+    assert task.write_size == Coordinate(5, 5)
+
+
+def test_lambda_task_skips_non_overlapping_blocks(tmp_path):
+    """Blocks outside in_data.roi are skipped without error.
+
+    pytest tests/test_lambda_task.py::test_lambda_task_skips_non_overlapping_blocks
+    """
+    # in_data covers (0,0) to (10,10)
+    data = np.ones((10, 10), dtype=np.float32)
+    in_path = tmp_path / "data.zarr" / "raw"
+    prepare_ds(
+        in_path,
+        shape=data.shape,
+        voxel_size=Coordinate(1, 1),
+        dtype=data.dtype,
+        mode="w",
+    )[:] = data
+
+    # out_data covers (0,0) to (20,20) -- larger than in_data
+    out_path = tmp_path / "data.zarr" / "out"
+    prepare_ds(
+        out_path,
+        shape=(20, 20),
+        voxel_size=Coordinate(1, 1),
+        dtype=np.uint8,
+        mode="w",
+    )
+
+    task = LambdaTask(
+        in_data=Raw(store=in_path),
+        out_data=Labels(store=out_path),
+        init_out=False,
+        lambda_func=lambda x: (x * 2).astype(np.uint8),
+        block_size=Coordinate(10, 10),
+    )
+    task.init()
+
+    # Block entirely outside in_data.roi -- should be skipped
+    non_overlapping_block = daisy.Block(
+        total_roi=Roi((0, 0), (20, 20)),
+        read_roi=Roi((10, 10), (10, 10)),
+        write_roi=Roi((10, 10), (10, 10)),
+    )
+
+    with task.process_block_func() as process_block:
+        process_block(non_overlapping_block)
+
+    # The region should remain zeros (untouched)
+    result = task.out_data.array("r")[Roi((10, 10), (10, 10))]
+    np.testing.assert_array_equal(result, np.zeros((10, 10), dtype=np.uint8))

--- a/volara/__init__.py
+++ b/volara/__init__.py
@@ -1,5 +1,14 @@
-from . import datasets as datasets
-from . import dbs as dbs
+from importlib import import_module
+
+__all__ = ["datasets", "dbs", "__version__", "__version_info__"]
+
+
+def __getattr__(name: str):
+    if name in {"datasets", "dbs"}:
+        module = import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 __version__ = "1.0.5"
 __version_info__ = tuple(int(i) for i in __version__.split("."))

--- a/volara/blockwise/lambda_task.py
+++ b/volara/blockwise/lambda_task.py
@@ -31,17 +31,47 @@ class LambdaTask(BlockwiseTask):
     """
     The dtype of the output array. If None, it will be the same as the input array.
     """
-    block_size: PydanticCoordinate
+    init_out: bool = True
+    """
+    If True (default), ``init`` calls ``out_data.prepare(...)`` sized to
+    ``write_roi``. Set to False when ``out_data`` already exists on disk
+    (e.g. a larger volume that this task patches a window of) -- the task
+    will then skip preparation and write into the existing array in place.
+    With ``init_out=False`` the iteration ROI also switches from
+    ``in_data.roi`` to ``out_data.roi`` so the task scans the destination;
+    blocks that don't overlap ``in_data`` are skipped at process time.
+    """
+    task_name_suffix: str | None = None
+    """
+    Optional suffix appended to ``task_name`` to disambiguate multiple
+    invocations that share an ``out_data`` (e.g. when patching several
+    disjoint windows of a pre-existing destination with ``init_out=False``).
+    Daisy keys its block-done cache on ``task_name``, so without a suffix
+    a second run would inherit the first run's meta dir and either skip
+    legitimately-new blocks or raise on offset mismatches.
+    """
+    block_size: PydanticCoordinate | None = None
+    """
+    Block size in voxels. When omitted, defaults to ``out_data``'s
+    chunk shape if it exists on disk (the usual case for
+    ``init_out=False``), else falls back to ``in_data``'s chunk shape.
+    """
     fit: str = "shrink"
     read_write_conflict: bool = False
 
     @property
     def task_name(self) -> str:
-        return f"{self.out_data.name}-{self.task_type}"
+        base = f"{self.out_data.name}-{self.task_type}"
+        if self.task_name_suffix is not None:
+            return f"{base}-{self.task_name_suffix}"
+        return base
 
     @property
     def write_roi(self) -> Roi:
-        total_roi = self.in_data.array("r").roi
+        if self.init_out:
+            total_roi = self.in_data.array("r").roi
+        else:
+            total_roi = self.out_data.array("r").roi
         if self.roi is not None:
             total_roi = total_roi.intersect(self.roi)
         return total_roi
@@ -52,7 +82,14 @@ class LambdaTask(BlockwiseTask):
 
     @property
     def write_size(self) -> Coordinate:
-        return self.block_size * self.voxel_size
+        if self.block_size is not None:
+            block_voxels = Coordinate(self.block_size)
+        else:
+            try:
+                block_voxels = Coordinate(self.out_data.array("r").chunk_shape)
+            except FileNotFoundError:
+                block_voxels = Coordinate(self.in_data.array("r").chunk_shape)
+        return block_voxels * self.voxel_size
 
     @property
     def context_size(self) -> Coordinate:
@@ -63,14 +100,16 @@ class LambdaTask(BlockwiseTask):
         return [self.out_data]
 
     def drop_artifacts(self):
-        self.out_data.drop()
+        if self.init_out:
+            self.out_data.drop()
 
     def init(self):
         if self.out_array_dtype is not None:
             self._out_array_dtype = self.out_array_dtype
         else:
             self._out_array_dtype = self.in_data.array("r").dtype
-        self.init_out_array()
+        if self.init_out:
+            self.init_out_array()
 
     def init_out_array(self):
         in_data = self.in_data.array("r")
@@ -91,6 +130,9 @@ class LambdaTask(BlockwiseTask):
         destination = self.out_data.array("r+")
 
         def process_block(block):
-            destination[block.write_roi] = self.lambda_func(source[block.write_roi])
+            write_roi = block.write_roi.intersect(source.roi).intersect(destination.roi)
+            if write_roi.empty:
+                return
+            destination[write_roi] = self.lambda_func(source[write_roi])
 
         yield process_block

--- a/volara/blockwise/lambda_task.py
+++ b/volara/blockwise/lambda_task.py
@@ -78,7 +78,9 @@ class LambdaTask(BlockwiseTask):
 
     @property
     def voxel_size(self) -> Coordinate:
-        return self.in_data.array("r").voxel_size
+        if self.init_out:
+            return self.in_data.array("r").voxel_size
+        return self.out_data.array("r").voxel_size
 
     @property
     def write_size(self) -> Coordinate:

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -275,9 +275,9 @@ class Affs(Dataset):
             if not provided:
                 self.neighborhood = list(Coordinate(offset) for offset in neighborhood)
             else:
-                assert np.isclose(
-                    neighborhood, self.neighborhood
-                ).all(), f"(Neighborhood metadata) {neighborhood} != {self.neighborhood} (given Neighborhood)"
+                assert np.isclose(neighborhood, self.neighborhood).all(), (
+                    f"(Neighborhood metadata) {neighborhood} != {self.neighborhood} (given Neighborhood)"
+                )
         else:
             if not provided:
                 raise ValueError(

--- a/volara/utils.py
+++ b/volara/utils.py
@@ -99,9 +99,7 @@ class _CallablePydanticAnnotation:
 
         def from_b64(
             value: str,
-        ) -> (
-            Callable
-        ):  # Safe under the assumption that config files are user-owned (mode 700 tmp dirs).
+        ) -> Callable:  # Safe under the assumption that config files are user-owned (mode 700 tmp dirs).
             # Do not use in contexts where config files may be written by untrusted parties.
             return pickle.loads(base64.b64decode(value))
 


### PR DESCRIPTION
1) init_out. Sometimes you want to write into an array that already exists. This lets you avoid trying to initialize the output dataset. 2) task_name_suffic. If you have multiple lambda tasks writing to the same output array, this will let you differentiate the tasks 3) block size doesn't necessarily need to be passed in. We can simply use the blocksize of the write dataset to perfectly align our writes and avoid race conditions by default. Can still be set if you want to process larger blocks.

New features: Processes output dataset blocks to stick to the write dataset chunks. If input data is smaller than the output dataset (i.e. you are writing to a small piece of the output dataset), then blocks that don't intersect with the input data will simply be skipped