### PR TITLE
Helpers for accessing different store endpoints

### DIFF
--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -102,6 +102,7 @@ class Dataset(StrictBaseModel, ABC):
         """
         if not isinstance(self.store, Path):
             if isinstance(self.store, str) and self.store.startswith("s3://"):
+                # drop an s3 zarr
                 fs = self._s3fs()
                 try:
                     fs.rm(self.store, recursive=True)
@@ -124,6 +125,10 @@ class Dataset(StrictBaseModel, ABC):
             spoof_path.parent.mkdir(parents=True, exist_ok=True)
 
         if self.store.exists() and not self.writable:
+            """
+            If the store is not writable, it is an input to some task and we can
+            safely read from it.
+            """
             print("Symlinking", self.store)
             if not spoof_path.exists():
                 spoof_path.symlink_to(self.store.absolute(), target_is_directory=True)

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -91,6 +91,11 @@ class Dataset(StrictBaseModel, ABC):
 
     @property
     def name(self) -> str:
+        """
+        A name for this dataset. Often it is simply the name of the
+        path provided as the store. We use it to differentiate between
+        multiple runs of the same blockwise task on different data.
+        """
         if isinstance(self.store, Path):
             return self.store.name
         else:
@@ -308,9 +313,9 @@ class Affs(Dataset):
             if not provided:
                 self.neighborhood = list(Coordinate(offset) for offset in neighborhood)
             else:
-                assert np.isclose(
-                    neighborhood, self.neighborhood
-                ).all(), f"(Neighborhood metadata) {neighborhood} != {self.neighborhood} (given Neighborhood)"
+                assert np.isclose(neighborhood, self.neighborhood).all(), (
+                    f"(Neighborhood metadata) {neighborhood} != {self.neighborhood} (given Neighborhood)"
+                )
         else:
             if not provided:
                 raise ValueError(

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -54,28 +54,55 @@ class Dataset(StrictBaseModel, ABC):
 
     zarr_kwargs: dict = Field(default_factory=dict)
 
+    s3_kwargs: dict | None = None
+    """
+    Optional config for S3-compatible stores like Lyve Cloud
+    Leave as None for existing local / standard S3 behavior
+    """
+
+    def _s3fs(self):
+        import s3fs  # type: ignore[unresolved-import]
+
+        if self.s3_kwargs is None:
+            return s3fs.S3FileSystem()
+
+        return s3fs.S3FileSystem(**self.s3_kwargs)
+
+    @property
+    def prepared_store(self):
+        """
+        Return the actual object passed to prepare_ds/open_ds.
+
+        Existing behavior:
+        - Path -> Path
+        - normal s3:// string -> string
+
+        Custom S3 behavior:
+        - s3:// string + s3_kwargs -> fsspec mapper
+        """
+        if (
+            self.s3_kwargs is not None
+            and isinstance(self.store, str)
+            and self.store.startswith("s3://")
+        ):
+            return self._s3fs().get_mapper(self.store, check=False)
+
+        return self.store
+
     @property
     def name(self) -> str:
-        """
-        A name for this dataset. Often it is simply the name of the
-        path provided as the store. We use it to differentiate between
-        multiple runs of the same blockwise task on different data.
-        """
         if isinstance(self.store, Path):
             return self.store.name
         else:
-            return self.store.split("/")[-1]
+            return self.store.rstrip("/").split("/")[-1]
 
     def drop(self) -> None:
         """
-        Delete this dataset
+        Delete this dataset.
         """
         if not isinstance(self.store, Path):
             if isinstance(self.store, str) and self.store.startswith("s3://"):
-                # drop an s3 zarr
-                import s3fs  # type: ignore[unresolved-import]
-
-                fs = s3fs.S3FileSystem()
+                fs = self._s3fs()
                 try:
                     fs.rm(self.store, recursive=True)
                 except FileNotFoundError:
@@ -90,14 +117,13 @@ class Dataset(StrictBaseModel, ABC):
     def spoof(self, spoof_dir: Path):
         if not isinstance(self.store, Path):
             raise ValueError(f"Not spoofing dataset: store {self.store} is not a Path")
+
         spoof_path = spoof_dir / f"spoof_{self.name}"
+
         if not spoof_path.parent.exists():
             spoof_path.parent.mkdir(parents=True, exist_ok=True)
+
         if self.store.exists() and not self.writable:
-            """
-            If the store is not writable, it is an input to some task and we can
-            safely read from it.
-            """
             print("Symlinking", self.store)
             if not spoof_path.exists():
                 spoof_path.symlink_to(self.store.absolute(), target_is_directory=True)
@@ -122,7 +148,7 @@ class Dataset(StrictBaseModel, ABC):
     ) -> None:
         # prepare ds
         array = prepare_ds(
-            self.store,
+            self.prepared_store,
             shape=shape,
             offset=Coordinate(offset),
             voxel_size=Coordinate(voxel_size),
@@ -158,12 +184,14 @@ class Dataset(StrictBaseModel, ABC):
             "units": self.units if self.units is not None else None,
         }
         arr = open_ds(
-            self.store,
+            self.prepared_store,
             mode=mode,
             **{k: v for k, v in metadata.items() if v is not None},  # type: ignore[invalid-argument-type]
             **self.zarr_kwargs,
         )
+
         self.lazy_ops(arr)
+
         if self.channels is not None:
             if isinstance(self.channels, list):
                 for channels in self.channels:


### PR DESCRIPTION
Adds a `prepared_store` property to Dataset which returns the actual store to pass to prepare_ds and open_ds. This way different s3 store endpoints can be read from / written to

```py
# local path to store
dataset = Dataset(
    store=Path("/path/to/data.zarr/dataset"),
)

# previous s3 store behavior
dataset = Dataset(
    store="s3://bucket/path/to/data.zarr/dataset",
)

# updating store endpoint url
dataset = Dataset(
    store="s3://bucket/path/to/data.zarr/dataset",
    s3_kwargs={
        "anon": False,
        "profile": "profile",
        "client_kwargs": {
            "endpoint_url": "endpoint_url",
            "region_name": "region_name",
        },
    },
)
```