### PR TITLE
Db bottleneck

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,3 +109,154 @@ def block_2d() -> daisy.Block:
         read_roi=Roi((0, 0), (10, 10)),
         write_roi=Roi((0, 0), (10, 10)),
     )
+
+
+# ---------------------------------------------------------------------------
+# bulk_write helpers, shared by test_extract_frags.py and test_aff_agglom.py
+# ---------------------------------------------------------------------------
+
+BULK_NEIGHBORHOOD = [[1, 0], [0, 1]]
+BULK_SCORES = {"aff": [Coordinate(1, 0), Coordinate(0, 1)]}
+
+
+@pytest.fixture()
+def blocky_affs(tmp_path) -> Path:
+    """Affinities from a 4x4 grid of 5x5 labels over a 20x20 volume.
+
+    Sixteen regions gives several fragments per block and plenty of adjacencies
+
+    The label-derived affinities are deliberately perturbed with noise. Raw
+    `seg_to_affgraph` output is exactly 0 on every inter-region boundary, which
+    makes every edge weight exactly 0.0 - and then comparing bulk against
+    non-bulk weights cannot tell any two blocks apart, which defeats the point of
+    the comparison. Varying the boundary values makes a partial-boundary mean
+    differ from a whole-boundary one. The perturbation stays well inside the -0.5
+    bias, so mws still recovers the 16 regions.
+    """
+    labels = np.zeros((20, 20), dtype=np.uint64)
+    label = 1
+    for z in range(0, 20, 5):
+        for y in range(0, 20, 5):
+            labels[z : z + 5, y : y + 5] = label
+            label += 1
+
+    clean = seg_to_affgraph(labels, nhood=BULK_NEIGHBORHOOD).astype(np.float32)
+    noise = np.random.default_rng(0).random(clean.shape).astype(np.float32)
+    affs = (clean * 0.75 + noise * 0.25).astype(np.float32)
+
+    path = tmp_path / "test.zarr" / "bulk_affs"
+    arr = prepare_ds(
+        path,
+        shape=affs.shape,
+        voxel_size=Coordinate(1, 1),
+        dtype=affs.dtype,
+        mode="w",
+    )
+    arr[:] = affs
+    arr._source_data.attrs["neighborhood"] = BULK_NEIGHBORHOOD
+    return path
+
+
+class BulkHarness:
+    """Runs extract-frags / aff-agglom serially and reads back the DB rows.
+
+    Tasks are run through `run_blockwise(multiprocessing=False)`, because bulk
+    mode needs the orchestrator-side context that `task()` enters: that is what
+    drops and rebuilds the indexes, and on SQLite it is also what switches the
+    file from rollback-journal to WAL. Driving `process_block_func` alone leaves
+    that switch to happen while a write connection is already open, which SQLite
+    rejects with "database is locked".
+    """
+
+    def __init__(self, tmp_path, affs_path):
+        self.tmp_path = tmp_path
+        self.affs_path = affs_path
+
+    def db(self, tag) -> SQLite:
+        return SQLite(
+            path=self.tmp_path / f"bulk_{tag}.sqlite",
+            node_attrs={"size": "int"},
+            edge_attrs={"aff": "float"},
+            ndim=2,
+        )
+
+    def frags_path(self, tag) -> Path:
+        return self.tmp_path / "test.zarr" / f"bulk_frags_{tag}"
+
+    @staticmethod
+    def _run(task):
+        """Run serially, asserting every block succeeded.
+
+        Without this a task that failed every block would leave an empty DB and
+        every comparison in the callers would pass
+        """
+        state = task.run_blockwise(multiprocessing=False)[task.task_name]
+        assert state.failed_count == 0, f"{task.task_name}: {state.failed_count} failed"
+        assert state.orphaned_count == 0
+        assert state.completed_count > 0
+
+    def extract_frags(self, db, tag, bulk_write, block_size, context) -> np.ndarray:
+        from volara.blockwise import ExtractFrags
+        from volara.datasets import Affs, Labels
+
+        task = ExtractFrags(
+            db=db,
+            affs_data=Affs(store=self.affs_path),
+            frags_data=Labels(store=self.frags_path(tag)),
+            block_size=block_size,
+            context=context,
+            bias=[-0.5, -0.5],
+            # noise_eps left unset: both runs must see identical affinities for
+            # their fragments, and hence their node rows, to be comparable.
+            bulk_write=bulk_write,
+        )
+        self._run(task)
+        return task.frags_data.array("r")[:]
+
+    def aff_agglom(self, db, tag, bulk_write, block_size, context) -> None:
+        from volara.blockwise import AffAgglom
+        from volara.datasets import Affs, Labels
+
+        self._run(
+            AffAgglom(
+                db=db,
+                frags_data=Labels(store=self.frags_path(tag)),
+                affs_data=Affs(store=self.affs_path),
+                block_size=block_size,
+                context=context,
+                scores=BULK_SCORES,
+                bulk_write=bulk_write,
+            )
+        )
+
+    def pipeline(self, tag, bulk_write, block_size, context):
+        """extract-frags then aff-agglom into one DB
+
+        AffAgglom needs the nodes ExtractFrags writes, and on SQLite it also needs
+        the journal-mode switch ExtractFrags' bulk context already performed.
+        """
+        db = self.db(tag)
+        frags = self.extract_frags(db, tag, bulk_write, block_size, context)
+        self.aff_agglom(db, tag, bulk_write, block_size, context)
+        return db, frags
+
+    @staticmethod
+    def nodes(db) -> dict:
+        graph = db.open("r").read_graph()
+        return {
+            int(node): (tuple(int(p) for p in attrs["position"]), int(attrs["size"]))
+            for node, attrs in graph.nodes(data=True)
+        }
+
+    @staticmethod
+    def edges(db) -> dict:
+        graph = db.open("r").read_graph()
+        return {
+            (min(int(u), int(v)), max(int(u), int(v))): dict(data)
+            for u, v, data in graph.edges(data=True)
+        }
+
+
+@pytest.fixture()
+def bulk(tmp_path, blocky_affs) -> BulkHarness:
+    return BulkHarness(tmp_path, blocky_affs)

--- a/tests/test_aff_agglom.py
+++ b/tests/test_aff_agglom.py
@@ -1,4 +1,7 @@
+import sqlite3
+
 import numpy as np
+import pytest
 from funlib.geometry import Coordinate
 from funlib.persistence.arrays import prepare_ds
 
@@ -97,3 +100,132 @@ def test_aff_agglom_basic(frags_2d, sqlite_db_2d, block_2d, tmp_path):
             assert data["y_aff"] == 0.0
         else:
             assert data["y_aff"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# bulk_write
+#
+# bulk_write=True changes three things about the block, not just the INSERT:
+#   - it skips the `rag_provider[read_roi]` read and starts from a bare
+#     `nx.Graph()`, so the graph has no node attributes at all;
+#   - because of that, edges cannot be filtered on node position the way
+#     `write_graph` does, so it substitutes its own filter: emit edge (u, v) if
+#     min(u, v) has voxels in block.write_roi;
+#   - writes go through `bulk_write_edges` inside a `bulk_write_mode` context.
+#
+# The tests run extract-frags first, both because aff-agglom needs the nodes it
+# writes and because on SQLite its bulk context is what switches the file to WAL.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "block_size, context",
+    [
+        (Coordinate(20, 20), Coordinate(0, 0)),
+        (Coordinate(10, 10), Coordinate(2, 2)),
+        (Coordinate(5, 20), Coordinate(2, 0)),
+    ],
+    ids=["single_block", "four_blocks_with_context", "row_blocks"],
+)
+def test_aff_agglom_bulk_matches_nonbulk(bulk, block_size, context):
+    """Same edges and the same weights either way.
+
+    `ExtractFrags` relabels each block independently and bumps ids by block id, so
+    every fragment lives in exactly one write_roi: the `min(u, v) in home_ids`
+    filter is an exact partition and each edge is emitted by exactly one block.
+    Weights must therefore match exactly, not just the edge set.
+    """
+    plain_db, _ = bulk.pipeline("plain", False, block_size, context)
+    bulk_db, _ = bulk.pipeline("bulk", True, block_size, context)
+
+    plain_edges, bulk_edges = bulk.edges(plain_db), bulk.edges(bulk_db)
+
+    assert len(plain_edges) > 0, "no edges written - comparison would be empty"
+    assert set(bulk_edges) == set(plain_edges)
+    for pair, data in plain_edges.items():
+        assert bulk_edges[pair]["aff"] == pytest.approx(data["aff"]), pair
+
+
+@pytest.mark.parametrize(
+    "extract_block, agglom_block",
+    [(Coordinate(10, 10), Coordinate(5, 5)), (Coordinate(5, 5), Coordinate(10, 10))],
+    ids=["agglom_blocks_smaller", "agglom_blocks_larger"],
+)
+def test_aff_agglom_bulk_matches_nonbulk_with_mismatched_block_sizes(
+    bulk, extract_block, agglom_block
+):
+    """AffAgglom tiled differently from ExtractFrags.
+
+    This is the one configuration where a fragment really can have voxels in
+    several agglom blocks, so the same edge is emitted more than once and
+    INSERT OR IGNORE picks whichever block committed first. The result still has
+    to match the non-bulk run.
+    """
+    results = {}
+    for tag, use_bulk in (("plain", False), ("bulk", True)):
+        db = bulk.db(tag)
+        bulk.extract_frags(db, tag, use_bulk, extract_block, Coordinate(2, 2))
+        bulk.aff_agglom(db, tag, use_bulk, agglom_block, Coordinate(2, 2))
+        results[tag] = bulk.edges(db)
+
+    assert len(results["plain"]) > 0
+    assert set(results["bulk"]) == set(results["plain"])
+    for pair, data in results["plain"].items():
+        assert results["bulk"][pair]["aff"] == pytest.approx(data["aff"]), pair
+
+
+def test_aff_agglom_bulk_finds_every_adjacency(bulk):
+    """The bulk filter keys on fragment id rather than node position. Check that
+    nothing is dropped: every adjacent pair of fragments in the volume gets an
+    edge."""
+    db, frags = bulk.pipeline("adjacency", True, Coordinate(10, 10), Coordinate(2, 2))
+
+    expected = set()
+    for axis in (0, 1):
+        base = np.take(frags, range(frags.shape[axis] - 1), axis=axis)
+        shifted = np.take(frags, range(1, frags.shape[axis]), axis=axis)
+        mask = (base != shifted) & (base > 0) & (shifted > 0)
+        for u, v in zip(base[mask], shifted[mask]):
+            expected.add((min(int(u), int(v)), max(int(u), int(v))))
+
+    assert set(bulk.edges(db)) == expected
+
+
+def test_aff_agglom_bulk_preserves_node_rows(bulk):
+    """AffAgglom writes edges only - it enters `bulk_write_mode` with
+    node_writes=False, so the node rows ExtractFrags wrote must survive intact."""
+    db = bulk.db("nodes")
+    bulk.extract_frags(db, "nodes", True, Coordinate(10, 10), Coordinate(2, 2))
+    before = bulk.nodes(db)
+
+    bulk.aff_agglom(db, "nodes", True, Coordinate(10, 10), Coordinate(2, 2))
+
+    assert bulk.nodes(db) == before
+
+
+@pytest.mark.xfail(
+    strict=True,
+    raises=sqlite3.OperationalError,
+    reason=(
+        "bulk_write on SQLite needs the file already in WAL mode. Running "
+        "aff-agglom with bulk_write=True as the first bulk task against a DB that "
+        "already holds rows fails: bulk_write_mode's rollback -> WAL "
+        "switch cannot take its exclusive lock while another connection is open, "
+        "and SQLite.open() never closes one. The normal pipeline is fine because a "
+        "bulk extract-frags switches the file first, while it is still empty."
+    ),
+)
+def test_aff_agglom_bulk_alone_on_a_non_wal_db(bulk):
+    """Re-running only aff-agglom in bulk mode over a DB from a non-bulk run.
+
+    Expected to fail today. Written strict so it turns into a failure the day it
+    is fixed, rather than being rediscovered.
+    """
+    db = bulk.db("nonwal")
+    bulk.extract_frags(db, "nonwal", False, Coordinate(10, 10), Coordinate(2, 2))
+    assert (
+        sqlite3.connect(db.path).execute("PRAGMA journal_mode").fetchone()[0]
+        == "delete"
+    )
+
+    bulk.aff_agglom(db, "nonwal", True, Coordinate(10, 10), Coordinate(2, 2))

--- a/tests/test_extract_frags.py
+++ b/tests/test_extract_frags.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from funlib.geometry import Coordinate
 
 from volara.blockwise import ExtractFrags
@@ -63,3 +64,73 @@ def test_extract_frags_basic(affs_2d, block_2d, tmp_path):
     for _, attrs in graph.nodes(data=True):
         assert "position" in attrs
         assert "size" in attrs
+
+
+# ---------------------------------------------------------------------------
+# bulk_write
+#
+# bulk_write=True is not just a faster INSERT. The block skips the
+# `rag_provider[write_roi]` read and starts from a bare `nx.Graph()`, then writes
+# via `bulk_write_graph` inside a `bulk_write_mode` context that drops and
+# rebuilds the node position index. The speedup only shows at volumes far past
+# unit-test scale, so what is pinned here is what must not drift: the rows that
+# end up in the database.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "block_size, context",
+    [
+        (Coordinate(20, 20), Coordinate(0, 0)),
+        (Coordinate(10, 10), Coordinate(2, 2)),
+        (Coordinate(5, 20), Coordinate(2, 0)),
+    ],
+    ids=["single_block", "four_blocks_with_context", "row_blocks"],
+)
+def test_extract_frags_bulk_matches_nonbulk(bulk, block_size, context):
+    """Same fragments and the same node rows either way.
+
+    Node attribution is unambiguous in both modes -- `bulk_write_nodes` still
+    filters on the node position, and the centroids are computed inside write_roi
+    -- so these must agree exactly, not merely as sets.
+    """
+    plain_db = bulk.db("plain")
+    plain_frags = bulk.extract_frags(plain_db, "plain", False, block_size, context)
+
+    bulk_db = bulk.db("bulk")
+    bulk_frags = bulk.extract_frags(bulk_db, "bulk", True, block_size, context)
+
+    np.testing.assert_array_equal(bulk_frags, plain_frags)
+
+    plain_nodes = bulk.nodes(plain_db)
+    assert len(plain_nodes) > 0, "no nodes written -- comparison would be vacuous"
+    assert bulk.nodes(bulk_db) == plain_nodes
+
+
+def test_extract_frags_bulk_writes_every_fragment(bulk):
+    """Every non-zero fragment in the output volume gets a node row.
+
+    Bulk mode starts from a bare graph instead of reading the RAG back, so a
+    filter mistake would silently under-write nodes rather than raise.
+    """
+    db = bulk.db("coverage")
+    frags = bulk.extract_frags(
+        db, "coverage", True, Coordinate(10, 10), Coordinate(2, 2)
+    )
+
+    assert set(bulk.nodes(db)) == {int(i) for i in np.unique(frags) if i != 0}
+
+
+def test_extract_frags_bulk_rebuilds_position_index(bulk):
+    """Bulk mode drops the node position index and must put it back, or every
+    later roi-restricted read degrades to a full table scan."""
+    db = bulk.db("index")
+    bulk.extract_frags(db, "index", True, Coordinate(10, 10), Coordinate(2, 2))
+
+    indexes = {
+        row[0]
+        for row in db.open("r")
+        .cur.execute("SELECT name FROM sqlite_master WHERE type='index'")
+        .fetchall()
+    }
+    assert "pos_index" in indexes

--- a/tests/test_relabel.py
+++ b/tests/test_relabel.py
@@ -1,9 +1,25 @@
+import daisy
 import numpy as np
-from funlib.geometry import Coordinate
+import pytest
+from funlib.geometry import Coordinate, Roi
 
 from volara.blockwise import Relabel
 from volara.datasets import Labels
 from volara.lut import LUT
+from volara.tmp import (
+    filter_mapping_to_block,
+    prepare_mapping,
+    replace_values,
+    replace_values_sorted,
+    warmup_replace_values_sorted,
+)
+
+
+def relabel_sorted(arr, src, dst):
+    """The faster relabel pipeline, chained exactly as `Relabel.map_block` does."""
+    src_sorted, dst_sorted = prepare_mapping(src, dst)
+    block_src, block_dst = filter_mapping_to_block(arr, src_sorted, dst_sorted)
+    return replace_values_sorted(np.ascontiguousarray(arr), block_src, block_dst)
 
 
 def test_relabel_init_and_drop(labels_2d, tmp_path):
@@ -48,3 +64,203 @@ def test_relabel_basic(labels_2d, block_2d, tmp_path):
     for frag_id, seg_id in [(1, 10), (2, 20), (3, 30), (4, 40)]:
         expected[frags_data == frag_id] = seg_id
     np.testing.assert_array_equal(result, expected)
+
+
+# ---------------------------------------------------------------------------
+# faster LUT relabel
+#
+# `replace_values` builds a numba typed dict of the whole LUT and probes it once
+# per voxel. `map_block` now instead sorts the LUT once per task
+# (`prepare_mapping`), narrows it to the ids actually present in the block
+# (`filter_mapping_to_block`), and binary-searches per voxel
+# (`replace_values_sorted`). Different lookup structure, a different mapping
+# size per block, and a different miss path -so what these tests pin is the one
+# thing that shouldnt change: the output array. `replace_values` is still in
+# `tmp.py` and serves as the reference.
+#
+# The speedup only shows on volumes far larger than a unit test should build, so
+# it is not asserted here.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "arr, src, dst, case",
+    [
+        # every value mapped
+        ([1, 2, 3, 4], [1, 2, 3, 4], [10, 20, 30, 40], "exhaustive"),
+        # values with no LUT entry pass through untouched
+        ([1, 2, 3, 99], [1, 2], [10, 20], "unmapped_passthrough"),
+        # background is just another id -- mapped if listed, kept if not
+        ([0, 1, 0, 2], [1, 2], [10, 20], "background_unmapped"),
+        ([0, 1, 0, 2], [0, 1, 2], [7, 10, 20], "background_mapped"),
+        # prepare_mapping sorts, so an unsorted LUT must behave identically
+        ([1, 2, 3, 4], [4, 1, 3, 2], [40, 10, 30, 20], "unsorted_lut"),
+        # LUT far wider than the block: filter_mapping_to_block drops the rest
+        ([5, 6], list(range(1, 21)), [i * 100 for i in range(1, 21)], "lut_superset"),
+        # ids entirely below / above the LUT, exercising both searchsorted ends
+        ([1, 2], [50, 51], [500, 510], "all_below_lut"),
+        ([90, 91], [50, 51], [500, 510], "all_above_lut"),
+        # empty LUT -> identity
+        ([1, 2, 3], [], [], "empty_lut"),
+        # full uint64 range, where a float64 detour would silently lose bits
+        (
+            [2**63 + 1, 2**63 + 2],
+            [2**63 + 1, 2**63 + 2],
+            [2**63 + 10, 2**63 + 20],
+            "uint64_range",
+        ),
+        # a mapping that permutes ids among themselves
+        ([1, 2, 3], [1, 2, 3], [3, 1, 2], "permutation"),
+        ([1, 2, 3], [1, 2, 3], [1, 2, 3], "identity"),
+    ],
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+def test_replace_values_sorted_matches_replace_values(arr, src, dst, case):
+    arr = np.array(arr, dtype=np.uint64)
+    src = np.array(src, dtype=np.uint64)
+    dst = np.array(dst, dtype=np.uint64)
+
+    expected = replace_values(arr, src, dst)
+    actual = relabel_sorted(arr, src, dst)
+
+    np.testing.assert_array_equal(actual, expected)
+    assert actual.dtype == expected.dtype
+
+
+@pytest.mark.parametrize("shape", [(10,), (4, 5), (3, 4, 5), (2, 3, 4, 5)])
+def test_replace_values_sorted_matches_replace_values_nd(shape):
+    """Shape is preserved and the values agree, 1D through 4D."""
+    arr = np.random.default_rng(0).integers(0, 12, size=shape).astype(np.uint64)
+    # Map only some of the ids, so both the hit and the miss path are exercised.
+    src = np.array([0, 2, 3, 5, 7, 11], dtype=np.uint64)
+    dst = np.array([100, 102, 103, 105, 107, 111], dtype=np.uint64)
+
+    actual = relabel_sorted(arr, src, dst)
+
+    assert actual.shape == shape
+    np.testing.assert_array_equal(actual, replace_values(arr, src, dst))
+
+
+def test_replace_values_sorted_matches_replace_values_sparse_lut():
+    """A wide, sparse LUT over many voxels - the regime `Relabel` runs in, where
+    most of the LUT is irrelevant to any single block."""
+    rng = np.random.default_rng(1)
+    arr = rng.integers(0, 5_000, size=(20, 30, 40)).astype(np.uint64)
+    src = rng.choice(20_000, size=8_000, replace=False).astype(np.uint64)
+    dst = (src + 1_000_000).astype(np.uint64)
+
+    np.testing.assert_array_equal(
+        relabel_sorted(arr, src, dst), replace_values(arr, src, dst)
+    )
+
+
+def test_prepare_mapping_sorts_and_keeps_pairs_together():
+    """The sort permutes both arrays, not just src."""
+    src = np.array([9, 3, 7, 1], dtype=np.uint64)
+    dst = np.array([90, 30, 70, 10], dtype=np.uint64)
+
+    src_sorted, dst_sorted = prepare_mapping(src, dst)
+
+    np.testing.assert_array_equal(src_sorted, [1, 3, 7, 9])
+    np.testing.assert_array_equal(dst_sorted, [10, 30, 70, 90])
+    assert src_sorted.flags["C_CONTIGUOUS"] and dst_sorted.flags["C_CONTIGUOUS"]
+
+
+def test_filter_mapping_to_block_keeps_only_present_ids():
+    """The per-block narrowing keeps exactly the entries whose src id occurs in the
+    block, so the binary search runs against the smallest possible table."""
+    src_sorted, dst_sorted = prepare_mapping(
+        np.array([1, 2, 3, 4, 5], dtype=np.uint64),
+        np.array([10, 20, 30, 40, 50], dtype=np.uint64),
+    )
+    block = np.array([[2, 2], [4, 99]], dtype=np.uint64)
+
+    block_src, block_dst = filter_mapping_to_block(block, src_sorted, dst_sorted)
+
+    np.testing.assert_array_equal(block_src, [2, 4])
+    np.testing.assert_array_equal(block_dst, [20, 40])
+
+
+def test_filter_mapping_to_block_empty_block_mapping():
+    """A block sharing no ids with the LUT narrows to an empty mapping, and the
+    relabel then leaves it alone."""
+    src_sorted, dst_sorted = prepare_mapping(
+        np.array([1, 2], dtype=np.uint64), np.array([10, 20], dtype=np.uint64)
+    )
+    block = np.array([[7, 8], [9, 9]], dtype=np.uint64)
+
+    block_src, block_dst = filter_mapping_to_block(block, src_sorted, dst_sorted)
+
+    assert block_src.size == 0 and block_dst.size == 0
+    np.testing.assert_array_equal(
+        replace_values_sorted(block, block_src, block_dst), block
+    )
+
+
+def test_warmup_replace_values_sorted_is_callable():
+    """`process_block_func` calls this before the block loop so the numba compile
+    does not land inside a timed block. It must not raise."""
+    warmup_replace_values_sorted()
+
+
+def test_relabel_task_matches_replace_values(labels_2d, block_2d, tmp_path):
+    """End to end: the task's output equals feeding the whole volume through
+    `replace_values` in one shot."""
+    frags_path, frags_data = labels_2d
+    lut = LUT(path=tmp_path / "lut.npz")
+    src = np.array([1, 2, 3, 4], dtype=np.uint64)
+    dst = np.array([10, 20, 30, 40], dtype=np.uint64)
+    lut.save(np.array([src, dst]))
+
+    task = Relabel(
+        frags_data=Labels(store=frags_path),
+        seg_data=Labels(store=tmp_path / "test.zarr" / "seg_oracle"),
+        lut=lut,
+        block_size=Coordinate(10, 10),
+    )
+    task.init()
+
+    with task.process_block_func() as process_block:
+        process_block(block_2d)
+
+    np.testing.assert_array_equal(
+        task.seg_data.array("r")[:],
+        replace_values(frags_data.astype(np.uint64), src, dst),
+    )
+
+
+def test_relabel_task_blockwise_matches_single_block(labels_2d, tmp_path):
+    """Splitting the volume into blocks changes nothing.
+
+    `map_block` narrows the LUT per block, so each block sees a *different*
+    mapping array. The stitched result must still equal the whole-volume answer.
+    """
+    frags_path, frags_data = labels_2d
+    lut = LUT(path=tmp_path / "lut.npz")
+    src = np.array([1, 2, 3, 4], dtype=np.uint64)
+    dst = np.array([10, 20, 30, 40], dtype=np.uint64)
+    lut.save(np.array([src, dst]))
+
+    total_roi = Roi((0, 0), (10, 10))
+    task = Relabel(
+        frags_data=Labels(store=frags_path),
+        seg_data=Labels(store=tmp_path / "test.zarr" / "seg_blockwise"),
+        lut=lut,
+        block_size=Coordinate(5, 5),
+    )
+    task.init()
+
+    with task.process_block_func() as process_block:
+        for z in range(0, 10, 5):
+            for y in range(0, 10, 5):
+                write_roi = Roi((z, y), (5, 5))
+                process_block(
+                    daisy.Block(
+                        total_roi=total_roi, read_roi=write_roi, write_roi=write_roi
+                    )
+                )
+
+    np.testing.assert_array_equal(
+        task.seg_data.array("r")[:],
+        replace_values(frags_data.astype(np.uint64), src, dst),
+    )

--- a/volara/blockwise/aff_agglom.py
+++ b/volara/blockwise/aff_agglom.py
@@ -1,8 +1,9 @@
 import logging
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from itertools import chain
-from typing import Annotated, Callable, Generator, Literal
+from typing import Annotated, Callable, Generator, Iterator, Literal
 
+import daisy
 import networkx as nx
 import numpy as np
 import scipy.ndimage
@@ -67,6 +68,14 @@ class AffAgglom(BlockwiseTask):
         }
 
     """
+
+    bulk_write: bool = False
+    """
+    Whether to bulk-write to database (false by default). This removes/rebuilds
+    indexes, and sets other useful flags for writing large amounts of data
+    quickly, which can be useful for large runs to prevent database bottlenecks.
+    """
+
     fit: Literal["shrink"] = "shrink"
     """
     The boundary behavior for our daisy task.
@@ -214,7 +223,12 @@ class AffAgglom(BlockwiseTask):
 
         with benchmark_logger.trace("Read data in block"):
             frags_data = frags.to_ndarray(block.read_roi, fill_value=0)
-            rag = rag_provider[block.read_roi]
+
+            if self.bulk_write:
+                rag = nx.Graph()
+            else:
+                rag = rag_provider[block.read_roi]
+                assert rag.number_of_edges() == 0, "RAG should contain no edges"
 
             affs_data = affs.to_ndarray(block.read_roi, fill_value=0)
 
@@ -229,7 +243,17 @@ class AffAgglom(BlockwiseTask):
             )
 
         with benchmark_logger.trace("Write RAG edges"):
-            rag_provider.write_graph(rag, block.write_roi, write_nodes=False)
+            if self.bulk_write:
+                rag_provider.bulk_write_graph(rag, block.write_roi, write_nodes=False)
+            else:
+                rag_provider.write_graph(rag, block.write_roi, write_nodes=False)
+
+    def _task_context(self, worker):
+        if self.bulk_write:
+            return self.db.open("r+").bulk_write_mode(
+                worker=worker, node_writes=False, edge_writes=True
+            )
+        return nullcontext()
 
     def init(self) -> None:
         self.db.init()
@@ -248,4 +272,19 @@ class AffAgglom(BlockwiseTask):
                 rag_provider,
             )
 
-        yield process_block
+        with self._task_context(worker=True):
+            yield process_block
+
+    @contextmanager
+    def task(
+        self,
+        upstream_tasks: daisy.Task | list[daisy.Task] | None = None,
+        multiprocessing: bool = True,
+    ) -> Iterator[daisy.Task]:
+
+        # temporary workaround since bulk_write_mode needs to modify the db
+        self.init()
+
+        with self._task_context(worker=False):
+            with super().task(upstream_tasks, multiprocessing) as task:
+                yield task

--- a/volara/blockwise/aff_agglom.py
+++ b/volara/blockwise/aff_agglom.py
@@ -228,7 +228,12 @@ class AffAgglom(BlockwiseTask):
                 rag = nx.Graph()
             else:
                 rag = rag_provider[block.read_roi]
-                assert rag.number_of_edges() == 0, "RAG should contain no edges"
+                # Note: cannot assert rag.number_of_edges() == 0 — read_roi
+                # extends into neighboring blocks' write_rois (non-zero
+                # context, read_write_conflict=False), so once any neighbor
+                # commits its edges they show up here through the context
+                # overlap. The downstream write_graph(write_roi) filter is
+                # what keeps each edge attributed to a single block.
 
             affs_data = affs.to_ndarray(block.read_roi, fill_value=0)
 
@@ -244,7 +249,23 @@ class AffAgglom(BlockwiseTask):
 
         with benchmark_logger.trace("Write RAG edges"):
             if self.bulk_write:
-                rag_provider.bulk_write_graph(rag, block.write_roi, write_nodes=False)
+                # In bulk mode the rag's nodes are bare (auto-created by
+                # add_edge), so funlib's bulk_write_edges roi/position
+                # filter would drop every edge — every node looks like
+                # "no position". Filter here by fragment id instead: emit
+                # edge (u, v) iff min(u, v) has voxels in block.write_roi.
+                # Fragments that straddle block boundaries may be emitted
+                # by more than one block; INSERT OR IGNORE in the bulk
+                # insert keeps the first writer's row.
+                write_frags_data = frags.to_ndarray(block.write_roi, fill_value=0)
+                home_ids = {int(i) for i in np.unique(write_frags_data) if i != 0}
+                filtered = nx.Graph()
+                for u, v, data in rag.edges(data=True):
+                    if min(int(u), int(v)) in home_ids:
+                        filtered.add_edge(u, v, **data)
+                rag_provider.bulk_write_edges(
+                    filtered.nodes, filtered.edges, roi=None
+                )
             else:
                 rag_provider.write_graph(rag, block.write_roi, write_nodes=False)
 

--- a/volara/blockwise/extract_frags.py
+++ b/volara/blockwise/extract_frags.py
@@ -4,6 +4,7 @@ from typing import Annotated, Iterator, Literal
 
 import daisy
 import mwatershed as mws
+import networkx as nx
 import numpy as np
 from funlib.geometry import Coordinate, Roi
 from funlib.persistence import Array
@@ -378,7 +379,13 @@ class ExtractFrags(BlockwiseTask):
             }
 
         with benchmark_logger.trace("Update RAG"):
-            rag = rag_provider[block.write_roi]
+            if self.bulk_write:
+                # since we drop indexes, the read_graph query has to check each
+                # node for containment which grows with cost as the db grows
+                rag = nx.Graph()
+            else:
+                rag = rag_provider[block.write_roi]
+                assert len(rag) == 0, "RAG should be empty"
 
             for node, data in fragment_centers.items():
                 # centers

--- a/volara/blockwise/extract_frags.py
+++ b/volara/blockwise/extract_frags.py
@@ -1,6 +1,6 @@
 import logging
-from contextlib import contextmanager
-from typing import Annotated, Literal
+from contextlib import contextmanager, nullcontext
+from typing import Annotated, Iterator, Literal
 
 import daisy
 import mwatershed as mws
@@ -111,6 +111,13 @@ class ExtractFrags(BlockwiseTask):
     The seed_eps is the scale to apply to the seed distance transform which is
     then subtracted from the shift. This is useful if increased fragmentation of
     the supervoxels is desired.
+    """
+
+    bulk_write: bool = False
+    """
+    Whether to bulk-write to database (false by default). This removes/rebuilds
+    indexes, and sets other useful flags for writing large amounts of data
+    quickly, which can be useful for large runs to prevent database bottlenecks.
     """
 
     fit: Literal["shrink"] = "shrink"
@@ -383,10 +390,23 @@ class ExtractFrags(BlockwiseTask):
 
                 rag.add_node(int(node), **node_attrs)
 
-            rag_provider.write_graph(
-                rag,
-                block.write_roi,
+            if self.bulk_write:
+                rag_provider.bulk_write_graph(
+                    rag,
+                    block.write_roi,
+                )
+            else:
+                rag_provider.write_graph(
+                    rag,
+                    block.write_roi,
+                )
+
+    def _task_context(self, worker):
+        if self.bulk_write:
+            return self.db.open("r+").bulk_write_mode(
+                worker=worker, node_writes=True, edge_writes=False
             )
+        return nullcontext()
 
     @contextmanager
     def process_block_func(self):
@@ -405,4 +425,19 @@ class ExtractFrags(BlockwiseTask):
                 mask=mask,
             )
 
-        yield process_block
+        with self._task_context(worker=True):
+            yield process_block
+
+    @contextmanager
+    def task(
+        self,
+        upstream_tasks: daisy.Task | list[daisy.Task] | None = None,
+        multiprocessing: bool = True,
+    ) -> Iterator[daisy.Task]:
+
+        # temporary workaround since bulk_write_mode needs to modify the db
+        self.init()
+
+        with self._task_context(worker=False):
+            with super().task(upstream_tasks, multiprocessing) as task:
+                yield task

--- a/volara/blockwise/relabel.py
+++ b/volara/blockwise/relabel.py
@@ -5,7 +5,12 @@ import numpy as np
 from funlib.geometry import Coordinate, Roi
 
 from volara.lut import LUT
-from volara.tmp import replace_values
+from volara.tmp import (
+    filter_mapping_to_block,
+    prepare_mapping,
+    replace_values_sorted,
+    warmup_replace_values_sorted,
+)
 
 from ..datasets import Dataset, Labels
 from ..utils import PydanticCoordinate
@@ -83,12 +88,26 @@ class Relabel(BlockwiseTask):
             dtype=self._out_array_dtype,
         )
 
-    def map_block(self, block, frags, segs, mapping):
+    def map_block(self, block, frags, segs, src_sorted, dst_sorted):
         benchmark_logger = self.get_benchmark_logger()
+
         with benchmark_logger.trace("Read Frags"):
-            in_frags = frags.to_ndarray(block.write_roi)
+            in_frags = np.ascontiguousarray(frags.to_ndarray(block.write_roi))
+
+        with benchmark_logger.trace("Filter Mapping"):
+            block_src, block_dst = filter_mapping_to_block(
+                in_frags,
+                src_sorted,
+                dst_sorted,
+            )
+
         with benchmark_logger.trace("Relabel"):
-            out_segs = replace_values(in_frags, mapping[0], mapping[1])
+            out_segs = replace_values_sorted(
+                in_frags,
+                block_src,
+                block_dst,
+            )
+
         with benchmark_logger.trace("Write Segments"):
             segs[block.write_roi] = out_segs
 
@@ -97,8 +116,12 @@ class Relabel(BlockwiseTask):
         frags = self.frags_data.array("r")
         segs = self.seg_data.array("r+")
 
+        mapping = self.lut.load()
+        src_sorted, dst_sorted = prepare_mapping(mapping[0], mapping[1])
+
+        warmup_replace_values_sorted()
+
         def process_block(block):
-            mapping = self.lut.load()
-            self.map_block(block, frags, segs, mapping)
+            self.map_block(block, frags, segs, src_sorted, dst_sorted)
 
         yield process_block

--- a/volara/tmp.py
+++ b/volara/tmp.py
@@ -102,3 +102,58 @@ def replace_values(arr, src, dst):
         relabeled_arr[i] = label_map.get(arr[i], arr[i])
 
     return relabeled_arr.reshape(shape)
+
+
+def prepare_mapping(src, dst):
+    src = np.asarray(src, dtype=np.uint64)
+    dst = np.asarray(dst, dtype=np.uint64)
+
+    order = np.argsort(src)
+
+    return (
+        np.ascontiguousarray(src[order]),
+        np.ascontiguousarray(dst[order]),
+    )
+
+
+def filter_mapping_to_block(in_frags, src_sorted, dst_sorted):
+    block_ids = np.unique(in_frags)
+
+    idx = np.searchsorted(src_sorted, block_ids)
+
+    valid = idx < src_sorted.size
+    idx = idx[valid]
+    block_ids = block_ids[valid]
+
+    matched = src_sorted[idx] == block_ids
+
+    return (
+        np.ascontiguousarray(src_sorted[idx[matched]]),
+        np.ascontiguousarray(dst_sorted[idx[matched]]),
+    )
+
+
+@numba.njit(parallel=True)
+def replace_values_sorted(arr, src_sorted, dst_sorted):
+    shape = arr.shape
+    flat = arr.ravel()
+    out = np.empty_like(flat)
+
+    for i in numba.prange(flat.size):
+        v = flat[i]
+        j = np.searchsorted(src_sorted, v)
+
+        if j < src_sorted.size and src_sorted[j] == v:
+            out[i] = dst_sorted[j]
+        else:
+            out[i] = v
+
+    return out.reshape(shape)
+
+
+def warmup_replace_values_sorted():
+    _ = replace_values_sorted(
+        np.zeros((4, 4, 4), dtype=np.uint64),
+        np.array([0], dtype=np.uint64),
+        np.array([0], dtype=np.uint64),
+    )


### PR DESCRIPTION
This PR adds bulk write option to fragment extraction and affinity agglomeration. This allows for better db write scaling by rebuilding indexes at the end. It also adds a faster relabeling for larger segmentation volumes, which may be better in a separate PR. Both changes tested on large data and seem to scale well linearly.