### PR TITLE
Add max_seed_decay_distance to frag extraction

### DIFF
--- a/volara/blockwise/extract_frags.py
+++ b/volara/blockwise/extract_frags.py
@@ -112,6 +112,13 @@ class ExtractFrags(BlockwiseTask):
     then subtracted from the shift. This is useful if increased fragmentation of
     the supervoxels is desired.
     """
+    max_seed_decay_distance: int | None = None
+    """
+    If using seeds and `seed_eps` is set, optionally cap the seed distance
+    transform used for affinity decay. This prevents the decay from growing
+    without bound deep inside large objects, which can otherwise lead to
+    unlabeled (`0`) interiors. If None, no cap is applied.
+    """
 
     fit: Literal["shrink"] = "shrink"
     read_write_conflict: Literal[False] = False
@@ -267,7 +274,12 @@ class ExtractFrags(BlockwiseTask):
 
             if self.seed_eps is not None:
                 D = distance_transform_edt(seeds == 0)
+
+                if self.max_seed_decay_distance is not None:
+                    D = np.minimum(D, self.max_seed_decay_distance)
+
                 shift -= self.seed_eps * D
+
         else:
             seeds = None
 
@@ -339,6 +351,7 @@ class ExtractFrags(BlockwiseTask):
 
             # ensure unique IDs
             id_bump = block.block_id[1] * self.num_voxels_in_block
+
             fragments_data[fragments_data > 0] += id_bump
 
         with benchmark_logger.trace("Write Fragments"):


### PR DESCRIPTION
This adds an option for capping the seed distance used if using an affinity decay. This is useful for increasing fragmentation of supervoxels without leading to unlabeled (`0`) interiors inside large objects (e.g cell bodies) due to unbounded decay growth. 