### PR TITLE
Optimize aff agglom

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "funlib.persistence>=0.7.0",
     "mwatershed>=0.5.2",
     "pydantic>=2.6.3",
+    "numpy>=2.0",
     "numba>=0.59.0",
     # llvmlite (numba dep) dropped macOS x86_64 wheels after 0.45; avoid source builds
     "llvmlite<0.46,!=0.44.*; platform_machine == 'x86_64' and sys_platform == 'darwin'",

--- a/tests/test_aff_agglom.py
+++ b/tests/test_aff_agglom.py
@@ -1,9 +1,97 @@
+"""Tests for AffAgglom.
+
+`AffAgglom.agglomerate` speedups - relabels fragments to a dense 1..k range with
+a single `np.unique(return_inverse=True)` rather than one full-array scan per
+fragment, and accumulates per-pair affinity statistics over only the boundary
+voxels using an integer cantor pairing and `np.bincount` rather than full-volume
+pairings handed to `scipy.ndimage.mean` / `sum_labels`. `reference_edges` below
+is a brute force test that walks every neighbour voxel pair and accumulates into
+a plain dict, using neither the relabel nor the cantor pairing, so agreement
+with it is should provide evidence that the optimization gives the same output.
+"""
+
+import networkx as nx
 import numpy as np
+import pytest
 from funlib.geometry import Coordinate
 from funlib.persistence.arrays import prepare_ds
 
 from volara.blockwise import AffAgglom
 from volara.datasets import Affs, Labels
+
+NEIGHBORHOOD_2D = [[1, 0], [0, 1]]
+
+
+def write_affs(path, data, neighborhood=NEIGHBORHOOD_2D):
+    arr = prepare_ds(
+        path,
+        shape=data.shape,
+        voxel_size=Coordinate(1, 1),
+        dtype=data.dtype,
+        mode="w",
+    )
+    arr[:] = data
+    arr._source_data.attrs["neighborhood"] = neighborhood
+    return path
+
+
+def make_task(db, frags_path, affs_path, scores) -> AffAgglom:
+    return AffAgglom(
+        db=db,
+        frags_data=Labels(store=frags_path),
+        affs_data=Affs(store=affs_path),
+        block_size=Coordinate(10, 10),
+        context=Coordinate(0, 0),
+        scores=scores,
+    )
+
+
+def agglomerate(task, affs, frags) -> dict:
+    """Run `agglomerate` on a fresh graph and return {(u, v): attrs}, with the
+    endpoints sorted so comparisons don't depend on edge orientation."""
+    rag = nx.Graph()
+    task.agglomerate(affs, frags, rag)
+    return {(min(u, v), max(u, v)): data for u, v, data in rag.edges(data=True)}
+
+
+def slices(offset):
+    base = tuple(slice(-m if m < 0 else None, -m if m > 0 else None) for m in offset)
+    shifted = tuple(slice(m if m > 0 else None, m if m < 0 else None) for m in offset)
+    return base, shifted
+
+
+def reference_edges(neighborhood, scores, affs, frags) -> dict:
+    """Brute-force per-pair affinity means.
+
+    Walks every voxel pair in the neighborhood one at a time and accumulates
+    (sum, count) into a dict keyed by the original fragment ids. A score's weight
+    is the mean affinity over all boundary voxels of all its offsets, which is
+    what `agglomerate`'s count-weighted combination reduces to.
+    """
+    totals = {name: {} for name in scores}
+    for score_name, offsets in scores.items():
+        for offset in offsets:
+            channel = list(neighborhood).index(offset)
+            base_slice, offset_slice = slices(offset)
+            base_frags = frags[base_slice]
+            offset_frags = frags[offset_slice]
+            base_affs = affs[channel][base_slice]
+            for idx in np.ndindex(base_frags.shape):
+                u, v = int(offset_frags[idx]), int(base_frags[idx])
+                if u == v or u == 0 or v == 0:
+                    continue
+                acc = totals[score_name].setdefault((min(u, v), max(u, v)), [0.0, 0])
+                acc[0] += float(base_affs[idx])
+                acc[1] += 1
+    return {
+        name: {pair: acc[0] / acc[1] for pair, acc in pairs.items()}
+        for name, pairs in totals.items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
 
 
 def test_aff_agglom_drop_edges(frags_2d, sqlite_db_2d, block_2d, tmp_path):
@@ -11,17 +99,11 @@ def test_aff_agglom_drop_edges(frags_2d, sqlite_db_2d, block_2d, tmp_path):
     frags_path, _ = frags_2d
 
     # Create 1-channel affs (needed for the task config, not for the drop test)
-    affs_data = np.zeros((1, 10, 10), dtype=np.float32)
-    affs_path = tmp_path / "test.zarr" / "affs"
-    arr = prepare_ds(
-        affs_path,
-        shape=affs_data.shape,
-        voxel_size=Coordinate(1, 1),
-        dtype=affs_data.dtype,
-        mode="w",
+    affs_path = write_affs(
+        tmp_path / "test.zarr" / "affs",
+        np.zeros((1, 10, 10), dtype=np.float32),
+        neighborhood=[[1, 0]],
     )
-    arr[:] = affs_data
-    arr._source_data.attrs["neighborhood"] = [[1, 0]]
 
     # Seed the DB with nodes and an edge
     db = sqlite_db_2d.open("r+")
@@ -36,14 +118,7 @@ def test_aff_agglom_drop_edges(frags_2d, sqlite_db_2d, block_2d, tmp_path):
     assert g.number_of_nodes() == 2
     assert g.number_of_edges() == 1
 
-    task = AffAgglom(
-        db=sqlite_db_2d,
-        frags_data=Labels(store=frags_path),
-        affs_data=Affs(store=affs_path),
-        block_size=Coordinate(10, 10),
-        context=Coordinate(0, 0),
-        scores={"y_aff": [Coordinate(1, 0)]},
-    )
+    task = make_task(sqlite_db_2d, frags_path, affs_path, {"y_aff": [Coordinate(1, 0)]})
     task.drop_artifacts()
 
     # Edges should be gone, nodes should remain
@@ -66,25 +141,11 @@ def test_aff_agglom_basic(frags_2d, sqlite_db_2d, block_2d, tmp_path):
     # Create 1-channel affs with offset [1,0]: 1 in every other row, 0 elsewhere
     affs_data = np.zeros((1, 10, 10), dtype=np.uint32)
     affs_data[0, ::2, :] = 1
-    affs_path = tmp_path / "test.zarr" / "affs"
-    arr = prepare_ds(
-        affs_path,
-        shape=affs_data.shape,
-        voxel_size=Coordinate(1, 1),
-        dtype=affs_data.dtype,
-        mode="w",
+    affs_path = write_affs(
+        tmp_path / "test.zarr" / "affs", affs_data, neighborhood=[[1, 0]]
     )
-    arr[:] = affs_data
-    arr._source_data.attrs["neighborhood"] = [[1, 0]]
 
-    task = AffAgglom(
-        db=sqlite_db_2d,
-        frags_data=Labels(store=frags_path),
-        affs_data=Affs(store=affs_path),
-        block_size=Coordinate(10, 10),
-        context=Coordinate(0, 0),
-        scores={"y_aff": [Coordinate(1, 0)]},
-    )
+    task = make_task(sqlite_db_2d, frags_path, affs_path, {"y_aff": [Coordinate(1, 0)]})
 
     with task.process_block_func() as process_block:
         process_block(block_2d)
@@ -97,3 +158,261 @@ def test_aff_agglom_basic(frags_2d, sqlite_db_2d, block_2d, tmp_path):
             assert data["y_aff"] == 0.0
         else:
             assert data["y_aff"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# edge weights
+# ---------------------------------------------------------------------------
+
+
+def test_agglomerate_weight_is_mean_over_all_boundary_voxels(
+    frags_2d, sqlite_db_2d, tmp_path
+):
+    """When one score groups several offsets, its weight is the mean affinity over
+    the boundary voxels of all of them pooled, not a mean of per-offset means.
+
+    Fragment 1 fills the top-left 5x5 corner of a block that is otherwise
+    fragment 2, so each offset contributes 5 boundary voxels: 5 at 0.2 along
+    (1, 0) and 5 at 0.6 along (0, 1). The pooled mean is 4.0 / 10 = 0.4, whereas
+    averaging the two per-offset means would also give 0.4 only because the counts
+    happen to match, so the asymmetric case is covered by the reference tests
+    below.
+    """
+    frags_path, _ = frags_2d
+
+    affs = np.zeros((2, 10, 10), dtype=np.float32)
+    affs[0, 4, 0:5] = 0.2  # (1, 0) boundary voxels
+    affs[1, 0:5, 4] = 0.6  # (0, 1) boundary voxels
+    affs_path = write_affs(tmp_path / "test.zarr" / "affs", affs)
+
+    frags = np.full((10, 10), 2, dtype=np.uint64)
+    frags[:5, :5] = 1
+
+    task = make_task(
+        sqlite_db_2d,
+        frags_path,
+        affs_path,
+        {"aff": [Coordinate(1, 0), Coordinate(0, 1)]},
+    )
+
+    edges = agglomerate(task, affs, frags)
+
+    assert set(edges) == {(1, 2)}
+    assert edges[(1, 2)]["aff"] == pytest.approx(0.4)
+
+
+def test_agglomerate_separate_scores_stay_separate(frags_2d, sqlite_db_2d, tmp_path):
+    """Each score name aggregates only its own offsets."""
+    frags_path, _ = frags_2d
+
+    affs = np.zeros((2, 10, 10), dtype=np.float32)
+    affs[0, 4, 0:5] = 0.2
+    affs[1, 0:5, 4] = 0.6
+    affs_path = write_affs(tmp_path / "test.zarr" / "affs", affs)
+
+    frags = np.full((10, 10), 2, dtype=np.uint64)
+    frags[:5, :5] = 1
+
+    task = make_task(
+        sqlite_db_2d,
+        frags_path,
+        affs_path,
+        {"z_aff": [Coordinate(1, 0)], "y_aff": [Coordinate(0, 1)]},
+    )
+
+    edges = agglomerate(task, affs, frags)
+
+    assert edges[(1, 2)]["z_aff"] == pytest.approx(0.2)
+    assert edges[(1, 2)]["y_aff"] == pytest.approx(0.6)
+
+
+def test_agglomerate_ignores_background(frags_2d, sqlite_db_2d, tmp_path):
+    """Two fragments separated by a row of background share no edge, even though
+    both touch the background."""
+    frags_path, _ = frags_2d
+
+    affs = np.ones((2, 10, 10), dtype=np.float32)
+    affs_path = write_affs(tmp_path / "test.zarr" / "affs", affs)
+
+    frags = np.zeros((10, 10), dtype=np.uint64)
+    frags[0:4] = 1
+    frags[5:10] = 2  # row 4 is background
+
+    task = make_task(
+        sqlite_db_2d,
+        frags_path,
+        affs_path,
+        {"aff": [Coordinate(1, 0), Coordinate(0, 1)]},
+    )
+
+    assert agglomerate(task, affs, frags) == {}
+
+
+def test_agglomerate_empty_block(frags_2d, sqlite_db_2d, tmp_path):
+    """An all-background block adds no edges and does not raise."""
+    frags_path, _ = frags_2d
+
+    affs = np.ones((2, 10, 10), dtype=np.float32)
+    affs_path = write_affs(tmp_path / "test.zarr" / "affs", affs)
+
+    task = make_task(sqlite_db_2d, frags_path, affs_path, {"aff": [Coordinate(1, 0)]})
+
+    assert agglomerate(task, affs, np.zeros((10, 10), dtype=np.uint64)) == {}
+
+
+# ---------------------------------------------------------------------------
+# dense relabel: edges must come back keyed by the original fragment ids
+# ---------------------------------------------------------------------------
+
+
+def test_agglomerate_reports_original_ids_without_background(
+    frags_2d, sqlite_db_2d, tmp_path
+):
+    """A block with no background at all.
+
+    `np.unique(return_inverse=True)` maps the lowest value to 0, so on a block
+    where nothing is background the relabel has to shift by one or the lowest
+    fragment is silently swallowed as background and loses all its edges.
+    """
+    frags_path, _ = frags_2d
+
+    affs = np.full((2, 10, 10), 0.5, dtype=np.float32)
+    affs_path = write_affs(tmp_path / "test.zarr" / "affs", affs)
+
+    frags = np.full((10, 10), 7, dtype=np.uint64)
+    frags[:5] = 5  # ids 5 and 7, no zeros anywhere
+
+    task = make_task(sqlite_db_2d, frags_path, affs_path, {"aff": [Coordinate(1, 0)]})
+
+    edges = agglomerate(task, affs, frags)
+
+    assert set(edges) == {(5, 7)}
+    assert edges[(5, 7)]["aff"] == pytest.approx(0.5)
+
+
+def test_agglomerate_reports_original_ids_for_large_labels(
+    frags_2d, sqlite_db_2d, tmp_path
+):
+    """Real fragment ids are block-bumped into the billions. The relabel exists so
+    the cantor pairing stays small; the edges still have to come back keyed by the
+    original ids."""
+    frags_path, _ = frags_2d
+
+    affs = np.full((2, 10, 10), 0.25, dtype=np.float32)
+    affs_path = write_affs(tmp_path / "test.zarr" / "affs", affs)
+
+    big = np.uint64(4_000_000_000)
+    frags = np.zeros((10, 10), dtype=np.uint64)
+    frags[0:5] = big
+    frags[5:10] = big + np.uint64(1)
+
+    task = make_task(sqlite_db_2d, frags_path, affs_path, {"aff": [Coordinate(1, 0)]})
+
+    edges = agglomerate(task, affs, frags)
+
+    assert set(edges) == {(int(big), int(big) + 1)}
+
+
+# ---------------------------------------------------------------------------
+# equivalence against the brute-force reference
+# ---------------------------------------------------------------------------
+
+
+def make_frags(layout) -> np.ndarray:
+    frags = np.zeros((10, 10), dtype=np.uint64)
+    if layout == "quadrants":
+        frags[:5, :5], frags[:5, 5:] = 1, 2
+        frags[5:, :5], frags[5:, 5:] = 3, 4
+    elif layout == "stripes":
+        frags[:] = np.arange(1, 11, dtype=np.uint64)[:, None]
+    elif layout == "no_background":
+        frags[:] = np.arange(11, 21, dtype=np.uint64)[None, :]
+    elif layout == "with_background_holes":
+        frags[:] = 1
+        frags[5:, :] = 2
+        frags[3:6, 3:6] = 0
+    elif layout == "random":
+        frags[:] = np.random.default_rng(2).integers(0, 5, size=(10, 10))
+    elif layout == "random_dense":
+        # No zeros, and many distinct pairs - the worst case for the relabel.
+        frags[:] = np.random.default_rng(3).integers(1, 8, size=(10, 10))
+    elif layout == "single":
+        frags[2:8, 2:8] = 42
+    elif layout == "large_ids":
+        frags[:5] = 4_000_000_000
+        frags[5:] = 4_000_000_017
+    else:
+        raise ValueError(layout)
+    return frags
+
+
+@pytest.mark.parametrize(
+    "layout",
+    [
+        "quadrants",
+        "stripes",
+        "no_background",
+        "with_background_holes",
+        "random",
+        "random_dense",
+        "single",
+        "large_ids",
+    ],
+)
+@pytest.mark.parametrize(
+    "scores",
+    [
+        {"aff": [Coordinate(1, 0)]},
+        {"aff": [Coordinate(1, 0), Coordinate(0, 1)]},
+        {"z_aff": [Coordinate(1, 0)], "y_aff": [Coordinate(0, 1)]},
+    ],
+    ids=["one_offset", "pooled_offsets", "split_scores"],
+)
+def test_agglomerate_matches_bruteforce(
+    frags_2d, sqlite_db_2d, tmp_path, layout, scores
+):
+    """The cantor-paired, boundary-only accumulation agrees with a per-voxel dict
+    walk, across fragment layouts and score groupings."""
+    frags_path, _ = frags_2d
+
+    # Random affinities so the per-pair means are all distinct -constant affs
+    # would let a mis-assigned pair pass unnoticed.
+    affs = np.random.default_rng(4).random((2, 10, 10)).astype(np.float32)
+    affs_path = write_affs(tmp_path / "test.zarr" / "affs", affs)
+
+    frags = make_frags(layout)
+    task = make_task(sqlite_db_2d, frags_path, affs_path, scores)
+
+    edges = agglomerate(task, affs, frags)
+    expected = reference_edges(task.affs_data.neighborhood, scores, affs, frags)
+
+    # An edge exists iff some score found boundary voxels for it
+    assert set(edges) == {pair for pairs in expected.values() for pair in pairs}
+
+    for pair, data in edges.items():
+        # ...and carries exactly the scores that did, with their weights. A score
+        # whose offsets never straddle this pair is absent, not zero.
+        assert set(data) == {
+            score_name for score_name, pairs in expected.items() if pair in pairs
+        }, pair
+        for score_name, value in data.items():
+            assert value == pytest.approx(expected[score_name][pair]), (
+                f"{score_name} on {pair}"
+            )
+
+
+def test_agglomerate_does_not_mutate_fragments(frags_2d, sqlite_db_2d, tmp_path):
+    """The relabel rebinds rather than writing into the caller's block, which
+    `agglomerate_in_block` hands straight from `to_ndarray`."""
+    frags_path, _ = frags_2d
+
+    affs = np.full((2, 10, 10), 0.5, dtype=np.float32)
+    affs_path = write_affs(tmp_path / "test.zarr" / "affs", affs)
+
+    frags = make_frags("large_ids")
+    original = frags.copy()
+
+    task = make_task(sqlite_db_2d, frags_path, affs_path, {"aff": [Coordinate(1, 0)]})
+    agglomerate(task, affs, frags)
+
+    np.testing.assert_array_equal(frags, original)

--- a/tests/test_extract_frags.py
+++ b/tests/test_extract_frags.py
@@ -1,9 +1,109 @@
+"""Tests for ExtractFrags.
+
+The fragment filter, the fragment centroids and the affinity-shift construction
+are all optimized - `np.bincount` over a `np.unique` inverse, and in-place
+arithmetic on a single buffer - rather than the standard per-label scipy calls.
+Speed is only worth having if the answer is unchanged, so each optimization has
+a `reference_*` helper below with the previous implementation, and an
+equivalence test asserting the two agree.
+"""
+
+import mwatershed as mws
 import numpy as np
+import pytest
 from funlib.geometry import Coordinate
+from funlib.persistence.arrays import prepare_ds
+from scipy import ndimage
 
 from volara.blockwise import ExtractFrags
 from volara.datasets import Affs, Labels
 from volara.dbs import SQLite
+from volara.tmp import replace_values
+
+
+def make_task(affs_path, tmp_path, **kwargs) -> ExtractFrags:
+    """An ExtractFrags over `affs_path`, for exercising its methods directly."""
+    return ExtractFrags(
+        db=SQLite(path=tmp_path / "test.zarr" / "unit_db.sqlite", ndim=2),
+        affs_data=Affs(store=affs_path),
+        frags_data=Labels(store=tmp_path / "test.zarr" / "unit_frags"),
+        block_size=Coordinate(10, 10),
+        context=Coordinate(0, 0),
+        bias=kwargs.pop("bias", [-0.5, -0.5]),
+        **kwargs,
+    )
+
+
+def write_affs(path, data, neighborhood) -> None:
+    arr = prepare_ds(
+        path,
+        shape=data.shape,
+        voxel_size=Coordinate(1, 1),
+        dtype=data.dtype,
+        mode="w",
+    )
+    arr[:] = data
+    arr._source_data.attrs["neighborhood"] = neighborhood
+
+
+# ---------------------------------------------------------------------------
+# previous reference implementations
+# ---------------------------------------------------------------------------
+
+
+def reference_filter_avg_fragments(affs, fragments_data, filter_value, ndim):
+    """`scipy.ndimage.mean` with an index array, which rescans the whole volume
+    once per label. `ExtractFrags.filter_avg_fragments` replaces this."""
+    average_affs = np.mean(affs[0:ndim], axis=0)
+    fragment_ids = np.unique(fragments_data)
+    filtered = [
+        fragment
+        for fragment, mean in zip(
+            fragment_ids, ndimage.mean(average_affs, fragments_data, fragment_ids)
+        )
+        if mean < filter_value
+    ]
+    filtered = np.array(filtered, dtype=fragments_data.dtype)
+    if filtered.size == 0:
+        return fragments_data
+    return replace_values(fragments_data, filtered, np.zeros_like(filtered))
+
+
+def reference_fragment_centers(fragments_data, offset, voxel_size):
+    """`scipy.ndimage.center_of_mass` over an explicit weight volume, alongside a
+    separate `unique(return_counts=True)`. `ExtractFrags.fragment_centers`
+    replaces this."""
+    fragment_ids, counts = np.unique(fragments_data, return_counts=True)
+    foreground = [(f, c) for f, c in zip(fragment_ids, counts) if f > 0]
+    if not foreground:
+        return {}
+    fragment_ids, counts = zip(*foreground)
+    centers = ndimage.center_of_mass(
+        np.ones_like(fragments_data), fragments_data, fragment_ids
+    )
+    return {
+        int(fragment_id): {
+            "center": offset + voxel_size * Coordinate(center),
+            "size": int(count),
+        }
+        for fragment_id, center, count in zip(fragment_ids, centers, counts)
+    }
+
+
+def reference_shift(affs_data, noise_eps, bias, rng):
+    """A zeroed buffer plus a separately-allocated noise volume. The real code
+    draws the noise straight into the buffer and folds the affinities in in
+    place, holding two volumes where this holds four."""
+    shift = np.zeros_like(affs_data)
+    if noise_eps is not None:
+        shift += rng.standard_normal(affs_data.shape, dtype=affs_data.dtype) * noise_eps
+    shift += np.array([bias]).reshape((-1, *((1,) * (len(affs_data.shape) - 1))))
+    return shift
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
 
 
 def test_extract_frags_init_and_drop(affs_2d, tmp_path):
@@ -63,3 +163,241 @@ def test_extract_frags_basic(affs_2d, block_2d, tmp_path):
     for _, attrs in graph.nodes(data=True):
         assert "position" in attrs
         assert "size" in attrs
+
+
+# ---------------------------------------------------------------------------
+# fragment_centers: bincount over a unique-inverse vs scipy center_of_mass
+# ---------------------------------------------------------------------------
+
+
+def test_fragment_centers_values(affs_2d, tmp_path):
+    """Centroids and sizes of two hand-placed fragments, in world units."""
+    affs_path, _ = affs_2d
+    task = make_task(affs_path, tmp_path)
+
+    fragments = np.zeros((10, 10), dtype=np.uint64)
+    fragments[:5, :5] = 1  # centroid (2, 2), 25 voxels
+    fragments[6:8, 2:4] = 7  # centroid (6.5, 2.5), 4 voxels
+
+    centers = task.fragment_centers(fragments, Coordinate(0, 0), Coordinate(1, 1))
+
+    assert set(centers) == {1, 7}
+    assert centers[1] == {"center": Coordinate(2, 2), "size": 25}
+    # Coordinate truncates, so the (6.5, 2.5) centroid lands on (6, 2).
+    assert centers[7] == {"center": Coordinate(6, 2), "size": 4}
+
+
+def test_fragment_centers_applies_offset_and_voxel_size(affs_2d, tmp_path):
+    """Centroids are reported in world space, not voxel space."""
+    affs_path, _ = affs_2d
+    task = make_task(affs_path, tmp_path)
+
+    fragments = np.zeros((10, 10), dtype=np.uint64)
+    fragments[:5, :5] = 1  # voxel centroid (2, 2)
+
+    centers = task.fragment_centers(fragments, Coordinate(100, 200), Coordinate(4, 8))
+
+    assert centers[1]["center"] == Coordinate(100 + 4 * 2, 200 + 8 * 2)
+
+
+def test_fragment_centers_excludes_background(affs_2d, tmp_path):
+    """Label 0 is background and never gets a node, however much of the block
+    it covers."""
+    affs_path, _ = affs_2d
+    task = make_task(affs_path, tmp_path)
+
+    fragments = np.zeros((10, 10), dtype=np.uint64)
+    fragments[0, 0] = 3
+
+    centers = task.fragment_centers(fragments, Coordinate(0, 0), Coordinate(1, 1))
+
+    assert set(centers) == {3}
+    assert centers[3]["size"] == 1
+
+
+def test_fragment_centers_empty(affs_2d, tmp_path):
+    """An all-background block yields no centers rather than raising."""
+    affs_path, _ = affs_2d
+    task = make_task(affs_path, tmp_path)
+
+    fragments = np.zeros((10, 10), dtype=np.uint64)
+
+    assert task.fragment_centers(fragments, Coordinate(0, 0), Coordinate(1, 1)) == {}
+
+
+@pytest.mark.parametrize(
+    "layout",
+    ["quadrants", "stripes", "sparse", "no_background", "random", "single"],
+)
+def test_fragment_centers_matches_scipy(affs_2d, tmp_path, layout):
+    """The bincount centroids equal scipy's center_of_mass, layout for layout."""
+    affs_path, _ = affs_2d
+    task = make_task(affs_path, tmp_path)
+
+    fragments = np.zeros((10, 10), dtype=np.uint64)
+    if layout == "quadrants":
+        fragments[:5, :5], fragments[:5, 5:] = 1, 2
+        fragments[5:, :5], fragments[5:, 5:] = 3, 4
+    elif layout == "stripes":
+        fragments[:] = np.arange(1, 11, dtype=np.uint64)[:, None]
+    elif layout == "sparse":
+        fragments[1, 1], fragments[8, 3:6], fragments[4:9, 9] = 12, 40, 7
+    elif layout == "no_background":
+        fragments[:] = 5
+        fragments[5:] = 7
+    elif layout == "random":
+        fragments[:] = np.random.default_rng(0).integers(0, 6, size=(10, 10))
+    elif layout == "single":
+        fragments[3:7, 3:7] = 99
+
+    offset, voxel_size = Coordinate(30, 40), Coordinate(2, 3)
+    assert task.fragment_centers(fragments, offset, voxel_size) == (
+        reference_fragment_centers(fragments, offset, voxel_size)
+    )
+
+
+def test_fragment_centers_matches_scipy_3d(affs_2d, tmp_path):
+    """The per-axis bincount loop has to hold in 3D, which is what the pipeline
+    actually runs. Anisotropic voxels so a transposed axis would show up."""
+    affs_path, _ = affs_2d
+    task = make_task(affs_path, tmp_path)
+
+    fragments = (
+        np.random.default_rng(5).integers(0, 8, size=(6, 9, 12)).astype(np.uint64)
+    )
+    offset, voxel_size = Coordinate(10, 20, 30), Coordinate(40, 8, 8)
+
+    assert task.fragment_centers(fragments, offset, voxel_size) == (
+        reference_fragment_centers(fragments, offset, voxel_size)
+    )
+
+
+# ---------------------------------------------------------------------------
+# filter_avg_fragments: bincount means vs scipy.ndimage.mean
+# ---------------------------------------------------------------------------
+
+
+def test_filter_avg_fragments_removes_low_affinity_fragments(affs_2d, tmp_path):
+    """Fragments whose mean direct-neighbour affinity is below the threshold are
+    zeroed; the rest are untouched."""
+    affs_path, _ = affs_2d
+    task = make_task(affs_path, tmp_path)
+
+    fragments = np.zeros((10, 10), dtype=np.uint64)
+    fragments[0:3], fragments[3:6], fragments[6:10] = 1, 2, 3
+    affs = np.zeros((2, 10, 10), dtype=np.float32)
+    affs[:, 0:3], affs[:, 3:6], affs[:, 6:10] = 0.1, 0.5, 0.9
+
+    filtered = task.filter_avg_fragments(affs, fragments, 0.3)
+
+    assert set(np.unique(filtered)) == {0, 2, 3}
+    assert (filtered[0:3] == 0).all()
+    assert (filtered[3:6] == 2).all()
+    assert (filtered[6:10] == 3).all()
+
+
+def test_filter_avg_fragments_no_op_leaves_block_unchanged(affs_2d, tmp_path):
+    """With every mean above the threshold the block comes back as it went in -
+    the early return skips a full-volume identity relabel."""
+    affs_path, _ = affs_2d
+    task = make_task(affs_path, tmp_path)
+
+    fragments = np.zeros((10, 10), dtype=np.uint64)
+    fragments[0:5], fragments[5:10] = 1, 2
+    affs = np.full((2, 10, 10), 0.9, dtype=np.float32)
+
+    filtered = task.filter_avg_fragments(affs, fragments, 0.5)
+
+    np.testing.assert_array_equal(filtered, fragments)
+
+
+def test_filter_avg_fragments_uses_only_direct_neighbour_offsets(tmp_path):
+    """Only the first `ndim` channels - the direct-neighbour offsets are
+    averaged. A high long-range channel must not rescue a low-affinity
+    fragment."""
+    affs_path = tmp_path / "test.zarr" / "affs_long_range"
+    affs = np.zeros((3, 10, 10), dtype=np.float32)
+    affs[0:2] = 0.1  # direct neighbours: mean 0.1
+    affs[2] = 1.0  # long range: would drag the mean up to 0.4
+    write_affs(affs_path, affs, [[1, 0], [0, 1], [4, 0]])
+
+    task = make_task(affs_path, tmp_path, bias=[-0.5, -0.5, -0.5])
+    fragments = np.ones((10, 10), dtype=np.uint64)
+
+    filtered = task.filter_avg_fragments(affs, fragments, 0.25)
+
+    assert (filtered == 0).all(), "long-range channel leaked into the mean"
+
+
+@pytest.mark.parametrize("filter_value", [0.05, 0.15, 0.35, 0.55, 1.5])
+def test_filter_avg_fragments_matches_scipy(affs_2d, tmp_path, filter_value):
+    """The bincount means pick the same fragments as scipy.ndimage.mean.
+
+    Affinities are keyed to the label value so each fragment's mean is exactly
+    `label / 10`, keeping the comparison away from float ties at the threshold.
+    """
+    affs_path, _ = affs_2d
+    task = make_task(affs_path, tmp_path)
+
+    fragments = np.random.default_rng(1).integers(0, 6, size=(10, 10)).astype(np.uint64)
+    affs = np.empty((2, 10, 10), dtype=np.float32)
+    affs[:] = fragments / 10.0
+
+    np.testing.assert_array_equal(
+        task.filter_avg_fragments(affs, fragments, filter_value),
+        reference_filter_avg_fragments(affs, fragments, filter_value, ndim=2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_fragments: one in-place buffer vs separate noise/sum allocations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("noise_eps", [None, 0.01, 0.5])
+def test_compute_fragments_matches_reference_shift(affs_2d, tmp_path, noise_eps):
+    """Building the shift in place gives the same fragments as building it out of
+    separate allocations, for the same noise draw."""
+    affs_path, affs = affs_2d
+    task = make_task(affs_path, tmp_path, noise_eps=noise_eps)
+
+    fragments = task.compute_fragments(affs.copy(), rng=np.random.default_rng(7))
+
+    shift = reference_shift(affs, noise_eps, task.bias, np.random.default_rng(7))
+    expected = mws.agglom(
+        (affs + shift).astype(np.float64),
+        offsets=task.neighborhood,
+        strides=None,
+        seeds=None,
+        randomized_strides=False,
+    )
+
+    np.testing.assert_array_equal(fragments, expected)
+
+
+def test_compute_fragments_is_reproducible_for_a_seeded_rng(affs_2d, tmp_path):
+    """Two calls with equally-seeded generators agree; `noise_eps` is the only
+    source of randomness `compute_fragments` reaches."""
+    affs_path, affs = affs_2d
+    task = make_task(affs_path, tmp_path, noise_eps=0.5)
+
+    first = task.compute_fragments(affs.copy(), rng=np.random.default_rng(0))
+    second = task.compute_fragments(affs.copy(), rng=np.random.default_rng(0))
+    other = task.compute_fragments(affs.copy(), rng=np.random.default_rng(1))
+
+    np.testing.assert_array_equal(first, second)
+    # A large noise_eps on binary affinities has to move at least one voxel,
+    # otherwise the seed is not actually reaching the noise.
+    assert not np.array_equal(first, other)
+
+
+def test_compute_fragments_does_not_mutate_affs(affs_2d, tmp_path):
+    """The shift is folded into the task's own buffer, not into the caller's
+    affinities -- filter_avg_fragments still has to read them afterwards."""
+    affs_path, affs = affs_2d
+    task = make_task(affs_path, tmp_path, noise_eps=0.1)
+
+    affs_data = affs.copy()
+    task.compute_fragments(affs_data, rng=np.random.default_rng(3))
+
+    np.testing.assert_array_equal(affs_data, affs)

--- a/volara/blockwise/aff_agglom.py
+++ b/volara/blockwise/aff_agglom.py
@@ -5,7 +5,6 @@ from typing import Annotated, Callable, Generator, Literal
 
 import networkx as nx
 import numpy as np
-import scipy.ndimage
 from daisy import Block
 from funlib.geometry import Coordinate, Roi
 from funlib.math import inv_cantor_number
@@ -76,21 +75,6 @@ class AffAgglom(BlockwiseTask):
     We don't have read write conflicts in this task and can compute
     every block independently in an arbitrary order.
     """
-    optimized: bool = False
-    """
-    Use the optimized implementations of the fragment relabel and the affinity
-    counting. Produces the same edges and weights as the original code, just
-    faster (measured 7.6x on the relabel, 40x on the counting):
-
-    - relabel via `np.unique(return_inverse=True)` instead of a full-array scan
-      per fragment (O(n_frags * n_voxels))
-    - affinity counting over only the boundary voxels, with an integer cantor
-      pairing and `np.bincount`, instead of full-volume float64 pairings handed
-      to `scipy.ndimage.mean` / `sum_labels`
-
-    Defaults to False so the original behavior is what you get unless you ask
-    for it. Set True to compare.
-    """
 
     @property
     def task_name(self) -> str:
@@ -122,37 +106,27 @@ class AffAgglom(BlockwiseTask):
         benchmark_logger = self.get_benchmark_logger()
 
         with benchmark_logger.trace("Preprocess fragments"):
-            # Both branches relabel fragments to a dense 1..k range so the cantor
-            # pairings in count_affs stay small, and produce the same mapping.
-            if self.optimized:
-                # np.unique(return_inverse=True) IS this relabel, done in C.
-                unique_vals, inverse = np.unique(frags, return_inverse=True)
-                # 0 sorts first, so when background is present inverse already
-                # maps 0 -> 0 and fragments -> 1..k in the same order the loop
-                # below produces. When the block has NO background, inverse would
-                # map the lowest fragment id to 0 and silently turn it into
-                # background, so shift by one in that case.
-                has_background = unique_vals.size > 0 and unique_vals[0] == 0
-                frags = inverse.reshape(frags.shape)
-                if not has_background:
-                    frags = frags + 1
-                frags = frags.astype(np.uint64)
+            # Relabel fragments to a dense 1..k range so the cantor pairings in
+            # count_affs stay small. np.unique(return_inverse=True) is this
+            # relabel, done in C, rather than one full-array scan per fragment
+            # (which was O(n_frags * n_voxels)).
+            unique_vals, inverse = np.unique(frags, return_inverse=True)
 
-                first_seq = 0 if has_background else 1
-                rev_mapping = {
-                    seq + first_seq: int(orig) for seq, orig in enumerate(unique_vals)
-                }
-                num_frags = unique_vals.size - (1 if has_background else 0)
-            else:
-                # Original: one full-array scan per fragment, O(n_frags * n_vox).
-                fragment_ids = [int(x) for x in np.unique(frags) if x != 0]
-                num_frags = len(fragment_ids)
-                frag_mapping = {
-                    old: seq for seq, old in zip(range(1, num_frags + 1), fragment_ids)
-                }
-                rev_mapping = {v: k for k, v in frag_mapping.items()}
-                for old, seq in frag_mapping.items():
-                    frags[frags == old] = seq
+            # 0 sorts first, so when background is present `inverse` already maps
+            # 0 -> 0 and fragments -> 1..k. When the block has NO background,
+            # `inverse` would map the lowest fragment id to 0 and silently turn it
+            # into background, so shift by one in that case.
+            has_background = unique_vals.size > 0 and unique_vals[0] == 0
+            frags = inverse.reshape(frags.shape)
+            if not has_background:
+                frags = frags + 1
+            frags = frags.astype(np.uint64)
+
+            first_seq = 0 if has_background else 1
+            rev_mapping = {
+                seq + first_seq: int(orig) for seq, orig in enumerate(unique_vals)
+            }
+            num_frags = unique_vals.size - (1 if has_background else 0)
 
             if num_frags == 0:
                 return
@@ -171,32 +145,7 @@ class AffAgglom(BlockwiseTask):
             )
             return base_slice, offset_slice
 
-        def count_affs_original(
-            fragments: np.ndarray, affinities: np.ndarray, offset: Coordinate
-        ) -> dict[int, tuple[float, float]]:
-            base_slice, offset_slice = slices(offset)
-            base_frags = fragments[base_slice]
-            base_affinities = affinities[base_slice]
-            offset_frags = fragments[offset_slice]
-
-            mask = (offset_frags != base_frags) * (offset_frags > 0) * (base_frags > 0)
-
-            # cantor pairing function
-            # 1/2 (k1 + k2)(k1 + k2 + 1) + k2
-            k1, k2 = (
-                np.min([offset_frags, base_frags], axis=0),
-                np.max([offset_frags, base_frags], axis=0),
-            )
-            cantor_pairings = ((k1 + k2) * (k1 + k2 + 1) / 2 + k2) * mask
-            cantor_ids = np.array([x for x in np.unique(cantor_pairings) if x != 0])
-            scores = scipy.ndimage.mean(base_affinities, cantor_pairings, cantor_ids)
-            counts = scipy.ndimage.sum_labels(mask, cantor_pairings, cantor_ids)
-            return {
-                cantor_id: (mean_score, count)
-                for cantor_id, mean_score, count in zip(cantor_ids, scores, counts)
-            }
-
-        def count_affs_optimized(
+        def count_affs(
             fragments: np.ndarray, affinities: np.ndarray, offset: Coordinate
         ) -> dict[int, tuple[float, float]]:
             base_slice, offset_slice = slices(offset)
@@ -207,11 +156,10 @@ class AffAgglom(BlockwiseTask):
             mask = (offset_frags != base_frags) & (offset_frags > 0) & (base_frags > 0)
 
             # Only voxels on a boundary between two distinct fragments carry an
-            # edge -- typically a few percent of the block. Select them first and
-            # do all the arithmetic on that small array, instead of computing
+            # edge - typically a few percent of the block. Select them first and
+            # do all the arithmetic on that small array, rather than computing
             # full-volume cantor pairings and handing them to
-            # scipy.ndimage.mean/sum_labels (which then rescan every voxel; that
-            # pair alone was ~85% of this function).
+            # scipy.ndimage.mean/sum_labels (which then rescan every voxel
             u_frags = offset_frags[mask].astype(np.uint64)
             v_frags = base_frags[mask].astype(np.uint64)
             if u_frags.size == 0:
@@ -219,7 +167,7 @@ class AffAgglom(BlockwiseTask):
 
             # cantor pairing function, in integers:
             # 1/2 (k1 + k2)(k1 + k2 + 1) + k2
-            # Kept in uint64 rather than float64 -- the ids are exact here,
+            # Kept in uint64 rather than float64 - the ids are exact here,
             # whereas float64 silently collides once the pairing exceeds 2**53.
             k1 = np.minimum(u_frags, v_frags)
             k2 = np.maximum(u_frags, v_frags)
@@ -235,8 +183,6 @@ class AffAgglom(BlockwiseTask):
                 int(cantor_id): (float(total / count), float(count))
                 for cantor_id, total, count in zip(cantor_ids, sums, counts)
             }
-
-        count_affs = count_affs_optimized if self.optimized else count_affs_original
 
         with benchmark_logger.trace("Count affinities"):
             for offset_affs, offset in zip(affs, self.affs_data.neighborhood):

--- a/volara/blockwise/aff_agglom.py
+++ b/volara/blockwise/aff_agglom.py
@@ -76,6 +76,21 @@ class AffAgglom(BlockwiseTask):
     We don't have read write conflicts in this task and can compute
     every block independently in an arbitrary order.
     """
+    optimized: bool = False
+    """
+    Use the optimized implementations of the fragment relabel and the affinity
+    counting. Produces the same edges and weights as the original code, just
+    faster (measured 7.6x on the relabel, 40x on the counting):
+
+    - relabel via `np.unique(return_inverse=True)` instead of a full-array scan
+      per fragment (O(n_frags * n_voxels))
+    - affinity counting over only the boundary voxels, with an integer cantor
+      pairing and `np.bincount`, instead of full-volume float64 pairings handed
+      to `scipy.ndimage.mean` / `sum_labels`
+
+    Defaults to False so the original behavior is what you get unless you ask
+    for it. Set True to compare.
+    """
 
     @property
     def task_name(self) -> str:
@@ -107,16 +122,39 @@ class AffAgglom(BlockwiseTask):
         benchmark_logger = self.get_benchmark_logger()
 
         with benchmark_logger.trace("Preprocess fragments"):
-            fragment_ids = [int(x) for x in np.unique(frags) if x != 0]
-            num_frags = len(fragment_ids)
-            frag_mapping = {
-                old: seq for seq, old in zip(range(1, num_frags + 1), fragment_ids)
-            }
-            rev_mapping = {v: k for k, v in frag_mapping.items()}
-            for old, seq in frag_mapping.items():
-                frags[frags == old] = seq
+            # Both branches relabel fragments to a dense 1..k range so the cantor
+            # pairings in count_affs stay small, and produce the same mapping.
+            if self.optimized:
+                # np.unique(return_inverse=True) IS this relabel, done in C.
+                unique_vals, inverse = np.unique(frags, return_inverse=True)
+                # 0 sorts first, so when background is present inverse already
+                # maps 0 -> 0 and fragments -> 1..k in the same order the loop
+                # below produces. When the block has NO background, inverse would
+                # map the lowest fragment id to 0 and silently turn it into
+                # background, so shift by one in that case.
+                has_background = unique_vals.size > 0 and unique_vals[0] == 0
+                frags = inverse.reshape(frags.shape)
+                if not has_background:
+                    frags = frags + 1
+                frags = frags.astype(np.uint64)
 
-            if len(fragment_ids) == 0:
+                first_seq = 0 if has_background else 1
+                rev_mapping = {
+                    seq + first_seq: int(orig) for seq, orig in enumerate(unique_vals)
+                }
+                num_frags = unique_vals.size - (1 if has_background else 0)
+            else:
+                # Original: one full-array scan per fragment, O(n_frags * n_vox).
+                fragment_ids = [int(x) for x in np.unique(frags) if x != 0]
+                num_frags = len(fragment_ids)
+                frag_mapping = {
+                    old: seq for seq, old in zip(range(1, num_frags + 1), fragment_ids)
+                }
+                rev_mapping = {v: k for k, v in frag_mapping.items()}
+                for old, seq in frag_mapping.items():
+                    frags[frags == old] = seq
+
+            if num_frags == 0:
                 return
 
             neighborhood_affs: dict[Coordinate, dict[int, tuple[float, float]]] = {}
@@ -124,60 +162,81 @@ class AffAgglom(BlockwiseTask):
             # affs_data.neighborhood cannot be None, assert called to make mypy happy
             assert self.affs_data.neighborhood is not None
 
-        def count_affs(
+        def slices(offset: Coordinate):
+            base_slice = tuple(
+                slice(-m if m < 0 else None, -m if m > 0 else None) for m in offset
+            )
+            offset_slice = tuple(
+                slice(m if m > 0 else None, m if m < 0 else None) for m in offset
+            )
+            return base_slice, offset_slice
+
+        def count_affs_original(
             fragments: np.ndarray, affinities: np.ndarray, offset: Coordinate
         ) -> dict[int, tuple[float, float]]:
-            base_frags = frags[
-                tuple(
-                    slice(-m if m < 0 else None, -m if m > 0 else None) for m in offset
-                )
-            ]
-            base_affinities = affinities[
-                tuple(
-                    slice(-m if m < 0 else None, -m if m > 0 else None) for m in offset
-                )
-            ]
-            offset_frags = fragments[
-                tuple(slice(m if m > 0 else None, m if m < 0 else None) for m in offset)
-            ]
+            base_slice, offset_slice = slices(offset)
+            base_frags = fragments[base_slice]
+            base_affinities = affinities[base_slice]
+            offset_frags = fragments[offset_slice]
 
             mask = (offset_frags != base_frags) * (offset_frags > 0) * (base_frags > 0)
 
             # cantor pairing function
             # 1/2 (k1 + k2)(k1 + k2 + 1) + k2
             k1, k2 = (
-                np.min(
-                    [
-                        offset_frags,
-                        base_frags,
-                    ],
-                    axis=0,
-                ),
-                np.max(
-                    [
-                        offset_frags,
-                        base_frags,
-                    ],
-                    axis=0,
-                ),
+                np.min([offset_frags, base_frags], axis=0),
+                np.max([offset_frags, base_frags], axis=0),
             )
             cantor_pairings = ((k1 + k2) * (k1 + k2 + 1) / 2 + k2) * mask
             cantor_ids = np.array([x for x in np.unique(cantor_pairings) if x != 0])
-            scores = scipy.ndimage.mean(
-                base_affinities,
-                cantor_pairings,
-                cantor_ids,
-            )
-            counts = scipy.ndimage.sum_labels(
-                mask,
-                cantor_pairings,
-                cantor_ids,
-            )
-            mapping = {
+            scores = scipy.ndimage.mean(base_affinities, cantor_pairings, cantor_ids)
+            counts = scipy.ndimage.sum_labels(mask, cantor_pairings, cantor_ids)
+            return {
                 cantor_id: (mean_score, count)
                 for cantor_id, mean_score, count in zip(cantor_ids, scores, counts)
             }
-            return mapping
+
+        def count_affs_optimized(
+            fragments: np.ndarray, affinities: np.ndarray, offset: Coordinate
+        ) -> dict[int, tuple[float, float]]:
+            base_slice, offset_slice = slices(offset)
+            base_frags = fragments[base_slice]
+            base_affinities = affinities[base_slice]
+            offset_frags = fragments[offset_slice]
+
+            mask = (offset_frags != base_frags) & (offset_frags > 0) & (base_frags > 0)
+
+            # Only voxels on a boundary between two distinct fragments carry an
+            # edge -- typically a few percent of the block. Select them first and
+            # do all the arithmetic on that small array, instead of computing
+            # full-volume cantor pairings and handing them to
+            # scipy.ndimage.mean/sum_labels (which then rescan every voxel; that
+            # pair alone was ~85% of this function).
+            u_frags = offset_frags[mask].astype(np.uint64)
+            v_frags = base_frags[mask].astype(np.uint64)
+            if u_frags.size == 0:
+                return {}
+
+            # cantor pairing function, in integers:
+            # 1/2 (k1 + k2)(k1 + k2 + 1) + k2
+            # Kept in uint64 rather than float64 -- the ids are exact here,
+            # whereas float64 silently collides once the pairing exceeds 2**53.
+            k1 = np.minimum(u_frags, v_frags)
+            k2 = np.maximum(u_frags, v_frags)
+            k_sum = k1 + k2
+            cantor_pairings = (k_sum * (k_sum + 1)) // 2 + k2
+
+            cantor_ids, inverse = np.unique(cantor_pairings, return_inverse=True)
+            weights = base_affinities[mask]
+            counts = np.bincount(inverse)
+            sums = np.bincount(inverse, weights=weights)
+
+            return {
+                int(cantor_id): (float(total / count), float(count))
+                for cantor_id, total, count in zip(cantor_ids, sums, counts)
+            }
+
+        count_affs = count_affs_optimized if self.optimized else count_affs_original
 
         with benchmark_logger.trace("Count affinities"):
             for offset_affs, offset in zip(affs, self.affs_data.neighborhood):

--- a/volara/blockwise/extract_frags.py
+++ b/volara/blockwise/extract_frags.py
@@ -8,7 +8,7 @@ import numpy as np
 from funlib.geometry import Coordinate, Roi
 from funlib.persistence import Array
 from pydantic import Field
-from scipy.ndimage import gaussian_filter, label, maximum_filter, measurements
+from scipy.ndimage import gaussian_filter, label, maximum_filter
 from scipy.ndimage.morphology import distance_transform_edt
 from skimage.measure import label as relabel
 from skimage.morphology import remove_small_objects
@@ -20,12 +20,6 @@ from ..utils import PydanticCoordinate
 from .blockwise import BlockwiseTask
 
 logger = logging.getLogger(__file__)
-
-# Module-level generator so the affinity noise can be made reproducible for
-# benchmarking / testing (`extract_frags._rng = np.random.default_rng(seed)`).
-# The previous code called the unseeded global `np.random.randn`, which made
-# fragment output non-reproducible run to run with no way to pin it.
-_rng = np.random.default_rng()
 
 
 class ExtractFrags(BlockwiseTask):
@@ -119,27 +113,6 @@ class ExtractFrags(BlockwiseTask):
     the supervoxels is desired.
     """
 
-    optimized: bool = False
-    """
-    Use the optimized implementations of the affinity-shift construction, the
-    fragment filter, and the fragment centroids. Produces the same fragments and
-    node attributes as the original code, just faster and with a much smaller
-    memory footprint:
-
-    - noise generated directly into `shift`, affinities folded in in place, and
-      the redundant `.astype(np.float64)` copy dropped -- the original allocated
-      up to six full (C, Z, Y, X) float64 volumes per block, this holds two
-    - per-fragment mean affinity and centroids via `np.bincount` instead of
-      `scipy.ndimage.mean` / `center_of_mass`, which rescan the whole volume per
-      label
-
-    Note the optimized path draws noise from the module-level `_rng`, which can
-    be seeded (`extract_frags._rng = np.random.default_rng(0)`); the original
-    path uses the unseeded global `np.random` and cannot be made reproducible.
-
-    Defaults to False to the original behavior. Set True to compare.
-    """
-
     fit: Literal["shrink"] = "shrink"
     read_write_conflict: Literal[False] = False
     _out_array_dtype: np.dtype = np.dtype(np.uint64)
@@ -199,47 +172,35 @@ class ExtractFrags(BlockwiseTask):
     def filter_avg_fragments(self, affs, fragments_data, filter_value):
         # Average over the direct-neighbour offsets only. Those are the first
         # `ndim` entries of the neighborhood (one per axis), so take the slice
-        # from the neighborhood's dimensionality rather than hardcoding 3 --
+        # from the neighborhood's dimensionality rather than hardcoding 3 -
         # otherwise a 2D neighborhood averages a long-range channel in here.
         ndim = len(self.neighborhood[0])
         average_affs = np.mean(affs[0:ndim], axis=0)
 
-        if self.optimized:
-            # Per-fragment mean affinity via unique + bincount instead of
-            # scipy.ndimage.measurements.mean with an index array, which rescans
-            # the whole volume per label. Same values, same order (np.unique is
-            # sorted), one pass.
-            fragment_ids, inverse = np.unique(fragments_data, return_inverse=True)
-            # numpy >= 2.0 returns `inverse` shaped like the input rather than
-            # flat, so ravel explicitly rather than rely on the version default.
-            inverse = inverse.reshape(-1)
-            counts = np.bincount(inverse)
-            sums = np.bincount(inverse, weights=average_affs.reshape(-1))
-            means = sums / counts
-            filtered_fragments = fragment_ids[means < filter_value].astype(
-                fragments_data.dtype
-            )
-        else:
-            filtered_fragments = []
-            fragment_ids = np.unique(fragments_data)
-            for fragment, mean in zip(
-                fragment_ids,
-                measurements.mean(average_affs, fragments_data, fragment_ids),
-            ):
-                if mean < filter_value:
-                    filtered_fragments.append(fragment)
-            filtered_fragments = np.array(
-                filtered_fragments, dtype=fragments_data.dtype
-            )
+        # Per-fragment mean affinity via unique + bincount, rather than
+        # scipy.ndimage.mean with an index array, which rescans the whole volume
+        # per label. Same values, same order (np.unique is sorted), one pass.
+        fragment_ids, inverse = np.unique(fragments_data, return_inverse=True)
+
+        # on numpy >= 2 `inverse` comes back shaped like
+        # the input, and bincount rejects anything but 1-D. On 1.x it was already
+        # flat and this is a no-op, so pinned to >=2 in toml.
+        inverse = inverse.reshape(-1)
+        counts = np.bincount(inverse)
+        sums = np.bincount(inverse, weights=average_affs.reshape(-1))
+        means = sums / counts
+        filtered_fragments = fragment_ids[means < filter_value].astype(
+            fragments_data.dtype
+        )
 
         if filtered_fragments.size == 0:
-            # Nothing to drop -- skip the full-volume relabel pass, which would
+            # Nothing to drop -skip the full-volume relabel pass, which would
             # otherwise be an identity copy of the whole block.
             return fragments_data
 
         replace = np.zeros_like(filtered_fragments)
 
-        # `replace_values` builds and returns a new array; it does NOT mutate
+        # `replace_values` builds and returns a new array; it does not mutate
         # `fragments_data`. Discarding this return made `filter_fragments` a
         # silent no-op.
         return replace_values(fragments_data, filtered_fragments, replace)
@@ -268,6 +229,46 @@ class ExtractFrags(BlockwiseTask):
 
         return fragments_data
 
+    def fragment_centers(
+        self,
+        fragments_data: np.ndarray,
+        offset: Coordinate,
+        voxel_size: Coordinate,
+    ) -> dict[int, dict]:
+        """
+        The world-space centroid and voxel count of every non-zero fragment.
+
+        A single np.unique plus one bincount per axis, rather than
+        `np.unique(return_counts=True)` alongside `scipy.ndimage.center_of_mass`
+        with an index array, which rescans the whole volume per label.
+        """
+        fragment_ids, inverse = np.unique(fragments_data, return_inverse=True)
+
+        # np >= 2 shapes `inverse` like the input and bincount only takes 1-D.
+        inverse = inverse.reshape(-1)
+        counts = np.bincount(inverse)
+
+        centers = np.empty((fragment_ids.size, fragments_data.ndim), dtype=np.float64)
+        for d in range(fragments_data.ndim):
+            # The coordinate ramp along axis `d`, broadcast rather than
+            # materialized - bincount reads it as a flat view.
+            bcast_shape = [1] * fragments_data.ndim
+            bcast_shape[d] = fragments_data.shape[d]
+            coord = np.broadcast_to(
+                np.arange(fragments_data.shape[d]).reshape(bcast_shape),
+                fragments_data.shape,
+            )
+            centers[:, d] = np.bincount(inverse, weights=coord.reshape(-1)) / counts
+
+        return {
+            int(fragment_id): {
+                "center": offset + voxel_size * Coordinate(center),
+                "size": int(count),
+            }
+            for fragment_id, center, count in zip(fragment_ids, centers, counts)
+            if fragment_id > 0
+        }
+
     def get_seeds(
         self,
         boundary_distances,
@@ -283,7 +284,18 @@ class ExtractFrags(BlockwiseTask):
 
         return seeds
 
-    def compute_fragments(self, affs_data):
+    def compute_fragments(self, affs_data, rng: np.random.Generator | None = None):
+        """
+        Mutex watershed on `affs_data`, returning the fragment labels.
+
+        `rng` supplies the `noise_eps` noise; pass a seeded generator to make a
+        call reproducible. Note that `randomized_strides=True` draws from its own
+        generator inside `mws.agglom` which this does not reach, so seeding here
+        only pins the noise.
+        """
+        if rng is None:
+            rng = np.random.default_rng()
+
         if self.sigma is not None:
             # add 0 for channel dim
             sigma = (0, *self.sigma)
@@ -295,26 +307,24 @@ class ExtractFrags(BlockwiseTask):
         # the exact same value the order they are processed in may be fifo, so
         # you can get annoying streaks.
 
-        if self.optimized and self.noise_eps is not None:
-            # Generate the noise straight into `shift` instead of
-            # `zeros_like` + `randn(*shape) * eps` + `+=`, which allocated three
+        if self.noise_eps is not None:
+            # Generate the noise straight into `shift` rather than
+            # `zeros_like` + `randn(*shape) * eps` + `+=`, which allocates three
             # full (C, Z, Y, X) float64 volumes (~2.2 GB each at full context)
             # to end up with one.
             shift = np.empty_like(affs_data)
             if shift.dtype in (np.float32, np.float64):
-                _rng.standard_normal(shift.shape, dtype=shift.dtype, out=shift)
+                rng.standard_normal(shift.shape, dtype=shift.dtype, out=shift)
             else:
-                shift[:] = _rng.standard_normal(shift.shape)
+                shift[:] = rng.standard_normal(shift.shape)
             shift *= self.noise_eps
         else:
             shift = np.zeros_like(affs_data)
-            if self.noise_eps is not None:
-                shift += np.random.randn(*affs_data.shape) * self.noise_eps
 
         #######################
 
-        # add smoothed affs, to solve a similar issue to the random noise. We want to bias
-        # towards processing the central regions of objects first.
+        # add smoothed affs, to solve a similar issue to the random noise. We
+        # want to bias towards processing the central regions of objects first.
 
         if sigma is not None:
             shift += gaussian_filter(affs_data, sigma=sigma) - affs_data
@@ -341,19 +351,14 @@ class ExtractFrags(BlockwiseTask):
         else:
             seeds = None
 
-        if self.optimized:
-            # `shift` is our own temporary, so fold the affinities into it in
-            # place rather than allocating `affs_data + shift` and copying that
-            # again via `.astype(np.float64)` (which copies even when already
-            # float64). `affs_data` itself must survive -- filter_avg_fragments
-            # still reads it.
-            shift += affs_data
-            agglom_input = shift.astype(np.float64, copy=False)
-        else:
-            agglom_input = (affs_data + shift).astype(np.float64)
+        # `shift` is our own temporary, so fold the affinities into it in place
+        # rather than allocating `affs_data + shift` and copying that again via
+        # `.astype(np.float64)` (which copies even when already float64).
+        # `affs_data` itself must survive - filter_avg_fragments still reads it.
+        shift += affs_data
 
         fragments_data = mws.agglom(
-            agglom_input,
+            shift.astype(np.float64, copy=False),
             offsets=self.neighborhood,
             strides=self.strides,
             seeds=seeds,
@@ -430,50 +435,12 @@ class ExtractFrags(BlockwiseTask):
             return
 
         with benchmark_logger.trace("Compute Fragment Centers"):
-            if self.optimized:
-                # A single np.unique plus one bincount per axis replaces both the
-                # separate np.unique(return_counts=True) and
-                # scipy center_of_mass(ones_like(...), ...), which rescanned the
-                # whole volume per label. Identical centroids and sizes.
-                fragment_ids, inverse = np.unique(fragments_data, return_inverse=True)
-                inverse = inverse.reshape(-1)  # numpy >= 2.0 keeps the input shape
-                counts = np.bincount(inverse)
-                logger.info("Found %d fragments", len(fragment_ids))
-
-                centers_of_masses = np.empty(
-                    (fragment_ids.size, fragments_data.ndim), dtype=np.float64
-                )
-                for d in range(fragments_data.ndim):
-                    bcast_shape = [1] * fragments_data.ndim
-                    bcast_shape[d] = fragments_data.shape[d]
-                    coord = np.broadcast_to(
-                        np.arange(fragments_data.shape[d]).reshape(bcast_shape),
-                        fragments_data.shape,
-                    )
-                    centers_of_masses[:, d] = (
-                        np.bincount(inverse, weights=coord.reshape(-1)) / counts
-                    )
-            else:
-                fragment_ids, counts = np.unique(fragments_data, return_counts=True)
-                logger.info("Found %d fragments", len(fragment_ids))
-                fragment_ids, counts = zip(
-                    *[(f, c) for f, c in zip(fragment_ids, counts) if f > 0]
-                )
-                centers_of_masses = measurements.center_of_mass(
-                    np.ones_like(fragments_data), fragments_data, fragment_ids
-                )
-
-            fragment_centers = {
-                int(fragment_id): {
-                    "center": block.write_roi.get_offset()
-                    + affs.voxel_size * Coordinate(center),
-                    "size": int(count),
-                }
-                for fragment_id, center, count in zip(
-                    fragment_ids, centers_of_masses, counts
-                )
-                if fragment_id > 0
-            }
+            fragment_centers = self.fragment_centers(
+                fragments_data,
+                block.write_roi.get_offset(),
+                affs.voxel_size,
+            )
+            logger.info("Found %d fragments", len(fragment_centers))
 
         with benchmark_logger.trace("Update RAG"):
             rag = rag_provider[block.write_roi]

--- a/volara/blockwise/extract_frags.py
+++ b/volara/blockwise/extract_frags.py
@@ -21,6 +21,12 @@ from .blockwise import BlockwiseTask
 
 logger = logging.getLogger(__file__)
 
+# Module-level generator so the affinity noise can be made reproducible for
+# benchmarking / testing (`extract_frags._rng = np.random.default_rng(seed)`).
+# The previous code called the unseeded global `np.random.randn`, which made
+# fragment output non-reproducible run to run with no way to pin it.
+_rng = np.random.default_rng()
+
 
 class ExtractFrags(BlockwiseTask):
     """
@@ -113,6 +119,27 @@ class ExtractFrags(BlockwiseTask):
     the supervoxels is desired.
     """
 
+    optimized: bool = False
+    """
+    Use the optimized implementations of the affinity-shift construction, the
+    fragment filter, and the fragment centroids. Produces the same fragments and
+    node attributes as the original code, just faster and with a much smaller
+    memory footprint:
+
+    - noise generated directly into `shift`, affinities folded in in place, and
+      the redundant `.astype(np.float64)` copy dropped -- the original allocated
+      up to six full (C, Z, Y, X) float64 volumes per block, this holds two
+    - per-fragment mean affinity and centroids via `np.bincount` instead of
+      `scipy.ndimage.mean` / `center_of_mass`, which rescan the whole volume per
+      label
+
+    Note the optimized path draws noise from the module-level `_rng`, which can
+    be seeded (`extract_frags._rng = np.random.default_rng(0)`); the original
+    path uses the unseeded global `np.random` and cannot be made reproducible.
+
+    Defaults to False to the original behavior. Set True to compare.
+    """
+
     fit: Literal["shrink"] = "shrink"
     read_write_conflict: Literal[False] = False
     _out_array_dtype: np.dtype = np.dtype(np.uint64)
@@ -170,22 +197,52 @@ class ExtractFrags(BlockwiseTask):
         )
 
     def filter_avg_fragments(self, affs, fragments_data, filter_value):
-        # tmp (think about this)
-        average_affs = np.mean(affs[0:3], axis=0)
+        # Average over the direct-neighbour offsets only. Those are the first
+        # `ndim` entries of the neighborhood (one per axis), so take the slice
+        # from the neighborhood's dimensionality rather than hardcoding 3 --
+        # otherwise a 2D neighborhood averages a long-range channel in here.
+        ndim = len(self.neighborhood[0])
+        average_affs = np.mean(affs[0:ndim], axis=0)
 
-        filtered_fragments = []
+        if self.optimized:
+            # Per-fragment mean affinity via unique + bincount instead of
+            # scipy.ndimage.measurements.mean with an index array, which rescans
+            # the whole volume per label. Same values, same order (np.unique is
+            # sorted), one pass.
+            fragment_ids, inverse = np.unique(fragments_data, return_inverse=True)
+            # numpy >= 2.0 returns `inverse` shaped like the input rather than
+            # flat, so ravel explicitly rather than rely on the version default.
+            inverse = inverse.reshape(-1)
+            counts = np.bincount(inverse)
+            sums = np.bincount(inverse, weights=average_affs.reshape(-1))
+            means = sums / counts
+            filtered_fragments = fragment_ids[means < filter_value].astype(
+                fragments_data.dtype
+            )
+        else:
+            filtered_fragments = []
+            fragment_ids = np.unique(fragments_data)
+            for fragment, mean in zip(
+                fragment_ids,
+                measurements.mean(average_affs, fragments_data, fragment_ids),
+            ):
+                if mean < filter_value:
+                    filtered_fragments.append(fragment)
+            filtered_fragments = np.array(
+                filtered_fragments, dtype=fragments_data.dtype
+            )
 
-        fragment_ids = np.unique(fragments_data)
+        if filtered_fragments.size == 0:
+            # Nothing to drop -- skip the full-volume relabel pass, which would
+            # otherwise be an identity copy of the whole block.
+            return fragments_data
 
-        for fragment, mean in zip(
-            fragment_ids, measurements.mean(average_affs, fragments_data, fragment_ids)
-        ):
-            if mean < filter_value:
-                filtered_fragments.append(fragment)
-
-        filtered_fragments = np.array(filtered_fragments, dtype=fragments_data.dtype)
         replace = np.zeros_like(filtered_fragments)
-        replace_values(fragments_data, filtered_fragments, replace)
+
+        # `replace_values` builds and returns a new array; it does NOT mutate
+        # `fragments_data`. Discarding this return made `filter_fragments` a
+        # silent no-op.
+        return replace_values(fragments_data, filtered_fragments, replace)
 
     def get_fragments(self, affs_data):
         fragments_data = self.compute_fragments(affs_data)
@@ -196,7 +253,9 @@ class ExtractFrags(BlockwiseTask):
 
         # filter fragments
         if self.filter_fragments > 0:
-            self.filter_avg_fragments(affs_data, fragments_data, self.filter_fragments)
+            fragments_data = self.filter_avg_fragments(
+                affs_data, fragments_data, self.filter_fragments
+            )
 
         # remove small debris
         if self.remove_debris > 0:
@@ -231,15 +290,26 @@ class ExtractFrags(BlockwiseTask):
         else:
             sigma = None
 
-        # add some random noise to affs (this is particularly necessary if your affs are
-        #  stored as uint8 or similar)
-        # If you have many affinities of the exact same value the order they are processed
-        # in may be fifo, so you can get annoying streaks.
+        # add some random noise to affs (this is particularly necessary if your
+        # affs are stored as uint8 or similar). If you have many affinities of
+        # the exact same value the order they are processed in may be fifo, so
+        # you can get annoying streaks.
 
-        shift = np.zeros_like(affs_data)
-
-        if self.noise_eps is not None:
-            shift += np.random.randn(*affs_data.shape) * self.noise_eps
+        if self.optimized and self.noise_eps is not None:
+            # Generate the noise straight into `shift` instead of
+            # `zeros_like` + `randn(*shape) * eps` + `+=`, which allocated three
+            # full (C, Z, Y, X) float64 volumes (~2.2 GB each at full context)
+            # to end up with one.
+            shift = np.empty_like(affs_data)
+            if shift.dtype in (np.float32, np.float64):
+                _rng.standard_normal(shift.shape, dtype=shift.dtype, out=shift)
+            else:
+                shift[:] = _rng.standard_normal(shift.shape)
+            shift *= self.noise_eps
+        else:
+            shift = np.zeros_like(affs_data)
+            if self.noise_eps is not None:
+                shift += np.random.randn(*affs_data.shape) * self.noise_eps
 
         #######################
 
@@ -271,8 +341,19 @@ class ExtractFrags(BlockwiseTask):
         else:
             seeds = None
 
+        if self.optimized:
+            # `shift` is our own temporary, so fold the affinities into it in
+            # place rather than allocating `affs_data + shift` and copying that
+            # again via `.astype(np.float64)` (which copies even when already
+            # float64). `affs_data` itself must survive -- filter_avg_fragments
+            # still reads it.
+            shift += affs_data
+            agglom_input = shift.astype(np.float64, copy=False)
+        else:
+            agglom_input = (affs_data + shift).astype(np.float64)
+
         fragments_data = mws.agglom(
-            (affs_data + shift).astype(np.float64),
+            agglom_input,
             offsets=self.neighborhood,
             strides=self.strides,
             seeds=seeds,
@@ -349,20 +430,44 @@ class ExtractFrags(BlockwiseTask):
             return
 
         with benchmark_logger.trace("Compute Fragment Centers"):
-            fragment_ids, counts = np.unique(fragments_data, return_counts=True)
-            logger.info("Found %d fragments", len(fragment_ids))
-            fragment_ids, counts = zip(
-                *[(f, c) for f, c in zip(fragment_ids, counts) if f > 0]
-            )
-            centers_of_masses = measurements.center_of_mass(
-                np.ones_like(fragments_data), fragments_data, fragment_ids
-            )
+            if self.optimized:
+                # A single np.unique plus one bincount per axis replaces both the
+                # separate np.unique(return_counts=True) and
+                # scipy center_of_mass(ones_like(...), ...), which rescanned the
+                # whole volume per label. Identical centroids and sizes.
+                fragment_ids, inverse = np.unique(fragments_data, return_inverse=True)
+                inverse = inverse.reshape(-1)  # numpy >= 2.0 keeps the input shape
+                counts = np.bincount(inverse)
+                logger.info("Found %d fragments", len(fragment_ids))
+
+                centers_of_masses = np.empty(
+                    (fragment_ids.size, fragments_data.ndim), dtype=np.float64
+                )
+                for d in range(fragments_data.ndim):
+                    bcast_shape = [1] * fragments_data.ndim
+                    bcast_shape[d] = fragments_data.shape[d]
+                    coord = np.broadcast_to(
+                        np.arange(fragments_data.shape[d]).reshape(bcast_shape),
+                        fragments_data.shape,
+                    )
+                    centers_of_masses[:, d] = (
+                        np.bincount(inverse, weights=coord.reshape(-1)) / counts
+                    )
+            else:
+                fragment_ids, counts = np.unique(fragments_data, return_counts=True)
+                logger.info("Found %d fragments", len(fragment_ids))
+                fragment_ids, counts = zip(
+                    *[(f, c) for f, c in zip(fragment_ids, counts) if f > 0]
+                )
+                centers_of_masses = measurements.center_of_mass(
+                    np.ones_like(fragments_data), fragments_data, fragment_ids
+                )
 
             fragment_centers = {
-                fragment_id: {
+                int(fragment_id): {
                     "center": block.write_roi.get_offset()
                     + affs.voxel_size * Coordinate(center),
-                    "size": count,
+                    "size": int(count),
                 }
                 for fragment_id, center, count in zip(
                     fragment_ids, centers_of_masses, counts


### PR DESCRIPTION
Adds optimizations to aff agglom via:

- relabel via `np.unique(return_inverse=True)` instead of a full-array scan per fragment (O(n_frags * n_voxels))
- affinity counting over only the boundary voxels, with an integer cantor pairing and `np.bincount`, instead of full-volume float64 pairings handed to `scipy.ndimage.mean` / `sum_labels`

Currently this runs via an "optimized" flag. If the changes look reasonable, then I will remove the optimized flag to make them default and add appropriate tests.