### PR TITLE
feat(blockwise): return the daisy TaskState map from run_blockwise on both paths

### DIFF
--- a/tests/test_run_blockwise_states.py
+++ b/tests/test_run_blockwise_states.py
@@ -1,0 +1,176 @@
+"""Tests for the daisy ``{task_id: TaskState}`` map returned by
+``BlockwiseTask.run_blockwise`` and ``Pipeline.run_blockwise``.
+
+Before this behavior existed, the multiprocessing path returned
+``daisy.run_blockwise``'s collapsed bool -- which reports ``True`` even when
+blocks fail, because ``TaskState.is_done()`` counts failed/orphaned blocks as
+"done" -- and ``Pipeline.run_blockwise`` returned ``None``. These tests pin the
+map return on both the serial and multiprocessing paths so a caller can see
+``failed_count`` / ``completed_count`` and react to a partial run.
+"""
+
+import numpy as np
+from daisy.task_state import TaskState
+from funlib.geometry import Coordinate
+from funlib.persistence.arrays import prepare_ds
+
+from volara.blockwise.lambda_task import LambdaTask
+from volara.datasets import Labels, Raw
+
+
+def _write_raw(path, data):
+    prepare_ds(
+        path,
+        shape=data.shape,
+        voxel_size=Coordinate(1, 1),
+        dtype=data.dtype,
+        mode="w",
+    )[:] = data
+    return path
+
+
+# A lambda that raises when a block's data exceeds a threshold. Passed through
+# volara's cloudpickle-based PydanticCallable, so it must be an expression --
+# hence the generator ``.throw`` idiom to raise inside the conditional.
+_FAIL_ON_HIGH = lambda x: (  # noqa: E731
+    (x > 0.5).astype(np.uint8)
+    if x.max() <= 1.5
+    else (_ for _ in ()).throw(RuntimeError("boom: block deliberately failed"))
+)
+
+
+def test_task_serial_returns_state_map(tmp_path):
+    """multiprocessing=False returns {task_id: TaskState}; all blocks complete.
+
+    pytest tests/test_run_blockwise_states.py::test_task_serial_returns_state_map
+    """
+    # 20x10 tiled into two 10x10 blocks
+    data = np.linspace(0, 1, 200, dtype=np.float32).reshape(20, 10)
+    in_path = _write_raw(tmp_path / "data.zarr" / "raw", data)
+
+    task = LambdaTask(
+        in_data=Raw(store=in_path),
+        out_data=Labels(store=tmp_path / "data.zarr" / "out"),
+        lambda_func=lambda x: (x > 0.5).astype(np.uint8),
+        block_size=Coordinate(10, 10),
+    )
+
+    states = task.run_blockwise(multiprocessing=False)
+
+    assert isinstance(states, dict)
+    assert task.task_name in states
+    state = states[task.task_name]
+    assert isinstance(state, TaskState)
+    assert state.total_block_count == 2
+    assert state.completed_count == 2
+    assert state.failed_count == 0
+    assert state.orphaned_count == 0
+    assert state.is_done()
+
+
+def test_task_multiprocessing_surfaces_failed_blocks(tmp_path):
+    """A worker function that raises on one block -> failed_count > 0.
+
+    This is the whole point of the PR: the returned map surfaces the failure,
+    whereas the old bool return would have reported success (is_done() is True
+    even with a failed block).
+
+    pytest tests/test_run_blockwise_states.py::test_task_multiprocessing_surfaces_failed_blocks
+    """
+    # block 0 (rows 0..10) is all 0.0 -> succeeds
+    # block 1 (rows 10..20) is all 2.0 -> lambda raises
+    data = np.zeros((20, 10), dtype=np.float32)
+    data[10:, :] = 2.0
+    in_path = _write_raw(tmp_path / "data.zarr" / "raw", data)
+
+    task = LambdaTask(
+        in_data=Raw(store=in_path),
+        out_data=Labels(store=tmp_path / "data.zarr" / "out"),
+        lambda_func=_FAIL_ON_HIGH,
+        block_size=Coordinate(10, 10),
+        num_workers=1,
+    )
+
+    states = task.run_blockwise(multiprocessing=True)
+
+    assert isinstance(states, dict)
+    state = states[task.task_name]
+    assert isinstance(state, TaskState)
+    assert state.total_block_count == 2
+    assert state.failed_count > 0
+    assert state.completed_count == 1
+    # is_done() counts failed blocks as "done" -- the reason a bool return
+    # cannot distinguish a clean run from one with failures.
+    assert state.is_done()
+
+
+def test_pipeline_serial_returns_merged_state_map(tmp_path):
+    """A sequential (``+``) Pipeline returns a merged map covering both tasks.
+
+    Previously Pipeline.run_blockwise returned None.
+
+    pytest tests/test_run_blockwise_states.py::test_pipeline_serial_returns_merged_state_map
+    """
+    data = np.linspace(0, 1, 200, dtype=np.float32).reshape(20, 10)
+    in_path = _write_raw(tmp_path / "data.zarr" / "raw", data)
+
+    task_a = LambdaTask(
+        in_data=Raw(store=in_path),
+        out_data=Labels(store=tmp_path / "data.zarr" / "out_a"),
+        lambda_func=lambda x: (x > 0.5).astype(np.uint8),
+        block_size=Coordinate(10, 10),
+    )
+    task_b = LambdaTask(
+        in_data=Raw(store=in_path),
+        out_data=Labels(store=tmp_path / "data.zarr" / "out_b"),
+        lambda_func=lambda x: (x > 0.3).astype(np.uint8),
+        block_size=Coordinate(10, 10),
+    )
+
+    pipeline = task_a + task_b
+    states = pipeline.run_blockwise(multiprocessing=False)
+
+    assert states is not None
+    assert isinstance(states, dict)
+    assert task_a.task_name in states
+    assert task_b.task_name in states
+    for task in (task_a, task_b):
+        state = states[task.task_name]
+        assert isinstance(state, TaskState)
+        assert state.completed_count == 2
+        assert state.failed_count == 0
+        assert state.is_done()
+
+
+def test_pipeline_multiprocessing_returns_merged_state_map(tmp_path):
+    """The Pipeline multiprocessing path also returns the merged map (not None).
+
+    pytest tests/test_run_blockwise_states.py::test_pipeline_multiprocessing_returns_merged_state_map
+    """
+    data = np.linspace(0, 1, 200, dtype=np.float32).reshape(20, 10)
+    in_path = _write_raw(tmp_path / "data.zarr" / "raw", data)
+
+    task_a = LambdaTask(
+        in_data=Raw(store=in_path),
+        out_data=Labels(store=tmp_path / "data.zarr" / "out_a"),
+        lambda_func=lambda x: (x > 0.5).astype(np.uint8),
+        block_size=Coordinate(10, 10),
+        num_workers=1,
+    )
+    task_b = LambdaTask(
+        in_data=Raw(store=in_path),
+        out_data=Labels(store=tmp_path / "data.zarr" / "out_b"),
+        lambda_func=lambda x: (x > 0.3).astype(np.uint8),
+        block_size=Coordinate(10, 10),
+        num_workers=1,
+    )
+
+    pipeline = task_a + task_b
+    states = pipeline.run_blockwise(multiprocessing=True)
+
+    assert states is not None
+    assert isinstance(states, dict)
+    assert task_a.task_name in states
+    assert task_b.task_name in states
+    for task in (task_a, task_b):
+        assert states[task.task_name].is_done()

--- a/volara/blockwise/blockwise.py
+++ b/volara/blockwise/blockwise.py
@@ -27,6 +27,35 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _run_blockwise_with_states(tasks):
+    """``daisy.run_blockwise``'s multiprocessing path, but returning daisy's
+    ``{task_id: TaskState}`` map instead of collapsing it to a bool (which hides failed /
+    orphaned blocks). Mirrors ``daisy.convenience._run_blockwise`` and its ThreadPool /
+    stop_event handling so a ``KeyboardInterrupt`` still stops the server cleanly. Defined at
+    module scope because ``BlockwiseTask.run_blockwise``'s ``multiprocessing`` parameter
+    shadows the stdlib module inside the method."""
+    from multiprocessing import Event
+    from multiprocessing.pool import ThreadPool
+
+    from daisy.tcp import IOLooper
+
+    stop_event = Event()
+    IOLooper.clear()
+
+    def _run():
+        server = daisy.Server(stop_event=stop_event)
+        _cl_monitor = CLMonitor(server)  # noqa: F841
+        return server.run_blockwise(tasks)
+
+    with ThreadPool(processes=1) as pool:
+        result = pool.apply_async(_run)
+        try:
+            return result.get()
+        except KeyboardInterrupt:
+            stop_event.set()
+            return result.get()
+
+
 class BlockwiseTask(StrictBaseModel, ABC):
     roi: PydanticRoi | None = None
     """
@@ -469,16 +498,21 @@ class BlockwiseTask(StrictBaseModel, ABC):
     ):
         """
         Execute this task blockwise.
+
+        Returns daisy's ``{task_id: TaskState}`` map for BOTH the multiprocessing and serial
+        paths. Previously the multiprocessing path went through ``daisy.run_blockwise``, which
+        collapses the states to a bool and, worse, reports ``True`` even when blocks failed
+        (``TaskState.is_done()`` counts failed/orphaned blocks as "done"). Returning the states
+        lets callers inspect ``failed_count`` / ``orphaned_count`` / ``is_done()`` and react to
+        an incomplete run instead of silently accepting a partial output.
         """
         with self.task(multiprocessing=multiprocessing) as task:
             tasks = [task]
             if multiprocessing:
-                result = daisy.run_blockwise(tasks)  # noqa
-            else:
-                server = daisy.SerialServer()
-                _cl_monitor = CLMonitor(server)
-                result = server.run_blockwise(tasks)
-            return result
+                return _run_blockwise_with_states(tasks)
+            server = daisy.SerialServer()
+            _cl_monitor = CLMonitor(server)  # noqa: F841
+            return server.run_blockwise(tasks)
 
     def __add__(self, other: "BlockwiseTask | Pipeline") -> "Pipeline":
         """

--- a/volara/blockwise/pipeline.py
+++ b/volara/blockwise/pipeline.py
@@ -140,6 +140,15 @@ class Pipeline:
             set_log_basedir(log_basedir)
 
     def run_blockwise(self, multiprocessing: bool = True):
+        """Execute every task in the pipeline.
+
+        Independent subgraphs (combined with ``|``) run concurrently in one daisy scheduling
+        pass; dependency edges (added by ``+``) are honored. Returns daisy's
+        ``{task_id: TaskState}`` map -- matching ``BlockwiseTask.run_blockwise`` -- so callers can
+        inspect ``failed_count`` / ``orphaned_count`` / ``is_done()`` instead of silently accepting
+        a partial run (the previous ``daisy.run_blockwise`` path collapsed the states to a bool
+        that reports ``True`` even when blocks failed).
+        """
         with ExitStack() as stack:
             node_ordering: list[BlockwiseTask] = list(
                 nx.topological_sort(self.task_graph)
@@ -163,11 +172,17 @@ class Pipeline:
             all_tasks = list(task_map.values())
 
             if multiprocessing:
-                daisy.run_blockwise(all_tasks)
+                # Return daisy's {task_id: TaskState} map via the states-returning helper
+                # (mirrors BlockwiseTask.run_blockwise) instead of the bool-collapsing
+                # daisy.run_blockwise, so a Pipeline surfaces failed/orphaned blocks too. Local
+                # import avoids the blockwise<->pipeline module cycle (see TYPE_CHECKING above).
+                from .blockwise import _run_blockwise_with_states
+
+                return _run_blockwise_with_states(all_tasks)
             else:
                 server = daisy.SerialServer()
                 _cl_monitor = daisy.cl_monitor.CLMonitor(server)  # type: ignore[unresolved-attribute]
-                server.run_blockwise(all_tasks)
+                return server.run_blockwise(all_tasks)
 
     def drop(self):
         for task in self.task_graph.nodes():


### PR DESCRIPTION
Resubmitted from #32, which bundled this feature with the daisy-v2 migration, a worker-model
refactor, a `graph_mws` timeout fix, a `dbs` fix and a ruff pass. @pattonw asked for it to be closed
and reopened with a description that matches the change — this is that. **Nothing here depends on
daisy v2; it targets `main` on daisy 1.x.**

`529/-118 across 11 files` → `233/-8 across 3 files`.

## Problem

`BlockwiseTask.run_blockwise` returns an inconsistent type: `dict[str, TaskState]` on the serial path
but a `bool` on the multiprocessing path (via `daisy.run_blockwise`). Worse, that bool is
`all(task_state.is_done() ...)`, and `TaskState.is_done()` counts failed/orphaned blocks as done — so
a run in which blocks failed still reports `True`, a partial output looks successful, and no caller
can tell.

## Reproduction

Two 10×10 blocks; the lambda raises on the second.

```python
import tempfile, numpy as np
from pathlib import Path
from funlib.geometry import Coordinate
from funlib.persistence.arrays import prepare_ds
from volara.blockwise.lambda_task import LambdaTask
from volara.datasets import Labels, Raw
from volara.logging import set_log_basedir

tmp = Path(tempfile.mkdtemp()); set_log_basedir(tmp / "logs")
# block 0 = all 0.0 -> succeeds; block 1 = all 9.0 -> the lambda raises
data = np.concatenate([np.zeros((10, 10), np.float32), np.full((10, 10), 9.0, np.float32)])
p = tmp / "d.zarr" / "raw"
prepare_ds(p, shape=data.shape, voxel_size=Coordinate(1, 1), dtype=data.dtype, mode="w")[:] = data

task = LambdaTask(
    in_data=Raw(store=p), out_data=Labels(store=tmp / "d.zarr" / "out"),
    lambda_func=lambda x: ((x > 0.5).astype(np.uint8) if x.max() <= 1.5
                           else (_ for _ in ()).throw(RuntimeError("boom"))),
    block_size=Coordinate(10, 10),
)
r = task.run_blockwise(multiprocessing=True)
print(type(r).__name__, "|", r)
```

**On `main`:**
```
bool | True
```
One of two blocks failed. The caller is told `True`.

**On this branch:**
```
defaultdict | {'out-lambda': TaskState(...)}
  total=2 completed=1 failed=1 orphaned=0 is_done()=True
```
Note `is_done()` is still `True` with a failed block — that is exactly why collapsing to
`all(is_done())` hid the failure. `failed_count` is what a caller has to inspect.

## Change

Return daisy's `{task_id: TaskState}` map on **both** paths. The multiprocessing path drives daisy's
`Server` directly via `_run_blockwise_with_states` — a deliberate mirror of
`daisy.convenience._run_blockwise` including the ThreadPool and `stop_event`, so `KeyboardInterrupt`
still stops the server cleanly — instead of the bool-collapsing convenience wrapper. `Pipeline.run_blockwise`
returns the merged map (it previously returned `None`).

Callers can now inspect `failed_count` / `orphaned_count` and react to an incomplete run rather than
silently accepting a partial output. Downstream (slabreg) uses this to raise on any failed or orphaned
block so a partial output never flows into the next stage.

## On fixing it in daisy instead

@pattonw's point on #32 was right, and it still stands: daisy already tracks and returns these states
— `Server.run_blockwise` and `SerialServer.run_blockwise` both return `{task_id: TaskState}`. The only
1.2.2 collapse is `daisy.convenience._run_blockwise` doing `return all(...)`. daisy 2.0 fixes it
properly.

Two things are worth separating, though:
- propagating the map through `BlockwiseTask.run_blockwise` **and** `Pipeline.run_blockwise` is our own
  API surface regardless of daisy — both were discarding what daisy handed back;
- `_run_blockwise_with_states` is the 1.2.2 bridge. It is deliberately isolated so that on daisy 2.0 it
  deletes and becomes a direct call, and the tests pin the return **contract**, not the helper.

## Tests

`tests/test_run_blockwise_states.py`, 4 cases: serial returns the map with the right `completed_count`;
a multiprocessing run whose worker raises returns `failed_count > 0` **while `is_done()` is `True`**
(the exact failure the bool hid); and a `Pipeline` returns the merged map on both paths.

```
$ pytest tests/test_run_blockwise_states.py -q
4 passed
```

Run against `daisy 1.2.2`. Note the import is `from daisy.task_state import TaskState`, which is the
1.x path — daisy 2.0 moves `TaskState` to the top level, so this file needs a one-line change as part
of the v2 migration rather than here.
