### PR TITLE
deps(daisy): cap daisy<2 until the v2 migration lands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">=3.11"
 
 dependencies = [
     "click>=8.0",
-    "daisy>=1.2.2",
+    "daisy>=1.2.2,<2",  # daisy 2.0 is a breaking Rust rewrite; see e11bio/volara#34
     "funlib.geometry>=0.3",
     "funlib.persistence>=0.7.0",
     "mwatershed>=0.5.2",


### PR DESCRIPTION
Split out of #32 as a standalone, one-line change. #32 went straight to a git pin on daisy's
unreleased `v2.0` branch, so the defensive cap that was step 1 of #34 never landed and `main` is
still exposed.

## Why

`main` declares `daisy>=1.2.2` with no upper bound, so a daisy 2.0.0 release on PyPI resolves for
every fresh install of volara `main` — and for every downstream repo that says `daisy>=1.2.2`
(volara-surface, volara-registration, frag_embed, slicing-metric all do).

**It does not fail loudly, which is the actual problem.** volara `main` imports fine against daisy
2.0.0 and the whole suite passes:

```
$ pip install 'daisy==2.0.0' && pytest tests -q
163 passed, 3 skipped, 2 xfailed
```

daisy v2's `v1_compat` layer still provides `cl_monitor`, `get_worker_log_basename`, `SerialServer`
and friends, so nothing in #34's import-break list actually raises. What changes is behaviour,
silently:

```python
>>> import daisy
>>> daisy.Context(hostname="h", port=1, task_id="t", worker_id=0).to_env()
```
| daisy | result |
|---|---|
| 1.x | `hostname=h:port=1:task_id=t:worker_id=0:logdir=<the driver's basedir>` |
| **2.0** | `hostname=h:task_id=t:port=1:worker_id=0` — **no `logdir`** |

`volara/blockwise/blockwise.py:260` reads `client.context["logdir"]` to recover the driver's log
basedir inside the worker. Under v2 that key is absent from the wire context, and v2's `Client.__init__`
re-injects it from the process-global `get_log_basedir()` — which its own comment describes as the value
*"fork-inheriting workers see as the value the master set."*

**volara's workers are spawned `volara-cli` processes, not forks.** So the global is daisy's default,
not the driver's. There is no `KeyError` and no crash — the worker silently resolves a *different*
basedir from the driver.

Since `BlockwiseTask.meta_dir` (and therefore `block_ds` / `blocks_done.zarr`) lives under the basedir,
driver and worker then address **different done-marker stores**: the driver's `init_block_array()`
creates a zarr Array, the worker's `open_ds(block_ds, mode="a")` creates a **Group** at its own
nonexistent path, and every block is orphaned while the driver log stays clean.

That failure has already cost real full-volume runs downstream. A cap is one line and it decouples the
daisy-2.0.0-release deadline from the migration work.

## Scope

```diff
-    "daisy>=1.2.2",
+    "daisy>=1.2.2,<2",  # daisy 2.0 is a breaking Rust rewrite; see e11bio/volara#34
```

No behaviour change on daisy 1.x, so there is no failing→passing example to show — the evidence above
is the *reason*, and the change itself is a constraint, not code. Remove the cap as part of the v2
migration.

Refs #34.
