### PR TITLE
fix(dbs): stop drop()/drop_edges() swallowing real Postgres failures

### DIFF
--- a/tests/test_dbs.py
+++ b/tests/test_dbs.py
@@ -97,3 +97,84 @@ def test_dbs(db_type: str, tmp_path):
         db.open("r")
 
     graph_provider = db.open("w")
+
+
+@pytest.mark.parametrize(
+    "db_type",
+    [
+        "sqlite",
+        pytest.param(
+            "postgresql",
+            marks=pytest.mark.skipif(
+                not psql_is_available(),
+                reason="PostgreSQL is not available",
+            ),
+        ),
+    ],
+)
+def test_drop_does_not_create(db_type: str, tmp_path):
+    """drop()/drop_edges() on a database that was never created must be a no-op and
+    must NOT bring the database into existence (regression for PR#33 review: a fresh
+    Postgres DB used to be created by drop() via open('w'))."""
+    db: DB
+    if db_type == "sqlite":
+        db = SQLite(
+            node_attrs={"color": 3},
+            edge_attrs={"y_aff": "float"},
+            ndim=2,
+            path=tmp_path / "never_created.sqlite",
+        )
+    else:
+        db = PostgreSQL(
+            node_attrs={"color": 3},
+            edge_attrs={"y_aff": "float"},
+            ndim=2,
+            name="volara_pytest_never_created",
+        )
+
+    # Sanity: the DB does not exist yet.
+    with pytest.raises(RuntimeError):
+        db.open("r")
+
+    # Dropping a non-existent DB is a successful no-op...
+    db.drop_edges()
+    db.drop()
+
+    # ...and must not have created it.
+    with pytest.raises(RuntimeError):
+        db.open("r")
+
+
+def test_drop_reraises_real_failures(monkeypatch):
+    """A real connection failure must NOT be swallowed by drop()/drop_edges().
+
+    Needs no live Postgres: the change is in the ``except`` clause, so we make
+    ``open()`` raise. Before the fix both methods caught every ``RuntimeError``,
+    so a refused connection was indistinguishable from a fresh database and the
+    drop silently "succeeded".
+
+    pytest tests/test_dbs.py::test_drop_reraises_real_failures
+    """
+    db = PostgreSQL(
+        node_attrs={"color": 3},
+        edge_attrs={"y_aff": "float"},
+        ndim=2,
+        name="volara_pytest_never_created",
+    )
+
+    def refused(*args, **kwargs):
+        raise RuntimeError("could not connect to server: Connection refused")
+
+    monkeypatch.setattr(PostgreSQL, "open", refused)
+    with pytest.raises(RuntimeError, match="Connection refused"):
+        db.drop()
+    with pytest.raises(RuntimeError, match="Connection refused"):
+        db.drop_edges()
+
+    # ...while a genuinely fresh database stays a silent no-op.
+    def fresh(*args, **kwargs):
+        raise RuntimeError("metadata does not exist")
+
+    monkeypatch.setattr(PostgreSQL, "open", fresh)
+    db.drop()
+    db.drop_edges()

--- a/volara/dbs.py
+++ b/volara/dbs.py
@@ -255,17 +255,25 @@ class PostgreSQL(DB):
     def drop(self) -> None:
         try:
             db = self.open("r+")
-            db._drop_tables()
-            db._create_tables()
-        except RuntimeError:
-            # DB doesn't exist yet
-            pass
+        except RuntimeError as e:
+            # A fresh database has no schema/metadata yet, so open('r+') (a read mode)
+            # raises "metadata does not exist". There is nothing to drop, so this is a
+            # successful no-op -- drop() must NEVER bring a database into existence
+            # (DB.init() is the only creator). Re-raise anything else so real failures
+            # (e.g. a broken connection) aren't silently swallowed.
+            if "metadata does not exist" in str(e):
+                return
+            raise
+        db._drop_tables()
+        db._create_tables()
 
     def drop_edges(self) -> None:
         try:
             db = self.open("r+")
-            db._drop_edges()
-            db._create_tables()
-        except RuntimeError:
-            # DB doesn't exist yet
-            pass
+        except RuntimeError as e:
+            # Fresh DB (no schema): nothing to drop, no-op. See drop() -- must not create.
+            if "metadata does not exist" in str(e):
+                return
+            raise
+        db._drop_edges()
+        db._create_tables()


### PR DESCRIPTION
Split out of #32, which bundled this with the daisy-v2 migration, the TaskState-map feature, a
worker-model refactor and a `graph_mws` timeout fix. Independent of all of them — targets `main`.

## The bug

`PostgreSQL.drop()` and `.drop_edges()` wrapped `open("r+")` in a bare `except RuntimeError: pass`.
The intent was *"a database that was never created has nothing to drop"* — a fresh Postgres DB has no
schema yet, so a read-mode open raises `metadata does not exist`.

But the same clause swallows **every** `RuntimeError`. A refused connection, bad credentials or an
unreachable host all made `drop()` return normally while doing nothing, so a caller that drops-then-
rebuilds proceeded against a database it never actually touched.

## Reproduction

No live Postgres needed — the change is in the `except` clause, so make `open()` raise.

```python
from volara.dbs import PostgreSQL

db = PostgreSQL(node_attrs={"color": 3}, edge_attrs={"y_aff": "float"}, ndim=2, name="demo")

def refused(*a, **k):                      # a REAL failure, not a fresh database
    raise RuntimeError("could not connect to server: Connection refused")
PostgreSQL.open = refused

try:
    db.drop()
    print("drop() -> returned normally: the connection error was SWALLOWED")
except RuntimeError as e:
    print(f"drop() -> re-raised: {e}")
```

**On `main`:**
```
drop() -> returned normally: the connection error was SWALLOWED
```

**On this branch:**
```
drop() -> re-raised: could not connect to server: Connection refused
```

A genuinely fresh database remains a silent no-op on both.

## Change

Catch only `"metadata does not exist"` and re-raise anything else. `drop()` still never brings a
database into existence — `DB.init()` remains the only creator.

## On the tests

This adds `test_drop_reraises_real_failures`, which covers the change and needs no live Postgres:

```
$ pytest tests/test_dbs.py -q
3 passed, 2 skipped        # on this branch

$ pytest tests/test_dbs.py -q
FAILED tests/test_dbs.py::test_drop_reraises_real_failures - Failed: DID NOT RAISE
1 failed, 2 passed, 2 skipped        # with volara/dbs.py from main
```

Worth flagging: `test_drop_does_not_create` (also added here, from #32) does **not** cover this fix.
Its `sqlite` parametrization never reaches the changed code, and its `postgresql` parametrization skips
wherever Postgres is absent — so it passes identically with and without the fix. It is still worth
keeping as a no-op/no-create guard; it just is not the regression test for this change.

The `postgresql` variants do run in CI, which has a Postgres service container.
