### PR TITLE
fix(logging): make the log basedir survive a spawned worker process

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,46 @@
+"""The log basedir has to survive a process boundary.
+
+volara spawns each worker as a fresh ``volara-cli`` PROCESS, so anything that only
+lives in a module-global is invisible to it. That matters beyond log placement:
+``BlockwiseTask.meta_dir`` -- and therefore ``block_ds`` (``blocks_done.zarr``) --
+lives under the basedir, so a driver and a worker that disagree about it address
+different done-marker stores and every block is orphaned with no driver-visible cause.
+"""
+
+import subprocess
+import sys
+
+from volara.logging import get_log_basedir, set_log_basedir
+
+_CHILD = "import volara.logging as L; print(L.get_log_basedir())"
+
+
+def test_basedir_survives_a_spawned_process(tmp_path):
+    """A child process must resolve the basedir its parent set.
+
+    pytest tests/test_logging.py::test_basedir_survives_a_spawned_process
+    """
+    basedir = tmp_path / "driver_basedir"
+    set_log_basedir(basedir)
+    assert get_log_basedir() == basedir
+
+    child = subprocess.run(
+        [sys.executable, "-c", _CHILD], capture_output=True, text=True, check=True
+    )
+    assert child.stdout.strip() == str(basedir), (
+        f"child resolved {child.stdout.strip()!r}, parent set {str(basedir)!r} -- a "
+        "spawned worker would address a different blocks_done store"
+    )
+
+
+def test_default_is_unchanged_when_nobody_sets_it(tmp_path, monkeypatch):
+    """With no basedir set anywhere, the default still applies.
+
+    pytest tests/test_logging.py::test_default_is_unchanged_when_nobody_sets_it
+    """
+    monkeypatch.delenv("VOLARA_LOG_BASEDIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+    child = subprocess.run(
+        [sys.executable, "-c", _CHILD], capture_output=True, text=True, check=True
+    )
+    assert child.stdout.strip() == "volara_logs"

--- a/volara/logging.py
+++ b/volara/logging.py
@@ -1,9 +1,19 @@
+import os
 from pathlib import Path
 
 import daisy
 
-# default log dir
-LOG_BASEDIR = Path("./volara_logs")
+# The log basedir must survive a process boundary. Workers are spawned as fresh `volara-cli`
+# PROCESSES that re-import this module, so a module-global alone silently reverts them to the
+# default while the driver uses something else -- and since BlockwiseTask.meta_dir lives under it,
+# driver and worker then read/write DIFFERENT blocks_done stores. The worker's `open_ds(..., "a")`
+# on its nonexistent path creates a zarr GROUP, so every block then fails with "Expected a zarr
+# Array ... got Group" and the run orphans every block with no driver-visible cause. Backing the
+# value with an env var makes subprocesses inherit it.
+LOG_BASEDIR_ENV = "VOLARA_LOG_BASEDIR"
+
+# default log dir (env wins, so a spawned worker matches the driver that set it)
+LOG_BASEDIR = Path(os.environ.get(LOG_BASEDIR_ENV, "./volara_logs"))
 daisy.logging.set_log_basedir(LOG_BASEDIR)
 
 
@@ -20,6 +30,8 @@ def set_log_basedir(path: Path | str):
 
     if path is not None:
         LOG_BASEDIR = Path(path)
+        # Export so spawned workers (fresh processes) resolve the SAME basedir as this driver.
+        os.environ[LOG_BASEDIR_ENV] = str(LOG_BASEDIR)
     else:
         raise NotImplementedError("None is not a valid log directory")
         LOG_BASEDIR = None


### PR DESCRIPTION
Replaces #39, which was stacked on #32's branch while targeting `main`, so its 16-line change showed as
543/-120 across 12 files. This is the same fix, standalone against `main`: **one file, 16 lines**, plus
the test that was missing.

@pattonw — this answers your question, and the answer changed what this PR should be.

## Your question (1) was right: it is a daisy v2 regression

You asked whether this is a daisy-v2 bug and, if so, to file it upstream with a minimal example. It is.
Filed: **funkelab/daisy#75**.

daisy 1.x put `logdir` into the worker `Context`, which is serialized into the `DAISY_CONTEXT`
**environment variable** — so it crossed *any* process boundary:

| daisy | `Context(...).to_env()` |
|---|---|
| 1.x | `hostname=…:port=…:task_id=…:worker_id=…:logdir=<the driver's basedir>` |
| **2.0** | `hostname=…:task_id=…:port=…:worker_id=…` — **no `logdir`** |

That is the mechanism volara relies on at `volara/blockwise/blockwise.py:260`. daisy v2 replaced it with
a fallback in `Client.__init__` that reads the *process-global* `get_log_basedir()`, described in its own
comment as the value *"fork-inheriting workers see as the value the master set."* **volara's workers are
spawned `volara-cli` processes, not forks**, so the global is daisy's default and
`client.context["logdir"]` is populated with the wrong path — no `KeyError`, nothing raises.

So you were right that it worked before. The mechanism that made it work was removed upstream.

## So why keep a volara-side change at all?

Reframing it accordingly — this is now a **guard**, not the fix:

1. It is independent of daisy. `set_log_basedir` is public volara API, and *any* caller who combines it
   with their own `multiprocessing`/`subprocess` spawn hits the same thing regardless of daisy version —
   on daisy 1.x too, if they never go through `daisy.Client`.
2. It closes the hole cheaply while daisy#75 is open, and stays harmless afterwards.
3. Default behaviour is unchanged when nobody sets a basedir.

If you'd rather wait for the upstream fix and take nothing here, that is a reasonable call and I'll close
this — the test below is worth landing either way, since it is the thing that would have caught this.

## Reproduction

```python
import subprocess, sys
from volara.logging import set_log_basedir

set_log_basedir("/tmp/driver_basedir")
print(subprocess.run(
    [sys.executable, "-c", "import volara.logging as L; print(L.get_log_basedir())"],
    capture_output=True, text=True).stdout.strip())
```

**On `main`:**
```
volara_logs
```

**On this branch:**
```
/tmp/driver_basedir
```

## Tests

`tests/test_logging.py` is new — **there was no test crossing a process boundary at all**, which is
exactly why this shipped. Against `volara/logging.py` from `main`:

```
FAILED tests/test_logging.py::test_basedir_survives_a_spawned_process
AssertionError: child resolved 'volara_logs', parent set '/tmp/.../driver_basedir'
             -- a spawned worker would address a different blocks_done store
1 failed, 1 passed
```

On this branch, and the full suite:

```
$ pytest tests/test_logging.py -q
2 passed

$ pytest tests -q
165 passed, 3 skipped, 2 xfailed          # main is 163 passed; +2 are the new tests
```

The second test pins that the default is unchanged when nobody sets a basedir.

## Known edges, worth stating rather than discovering later

- `VOLARA_LOG_BASEDIR` is never cleared, so a second run in the same process inherits the first run's
  basedir even if it never calls `set_log_basedir`. `conftest.py`'s autouse `logdir` fixture masks this
  in the suite.
- Two concurrent drivers in one process with different basedirs now race on a process-global env var —
  no worse than racing on a module global, but no better.
- `LOG_BASEDIR` is read at import, so a parent that sets the env var *directly* after importing
  `volara.logging` is not supported; going through `set_log_basedir` is.
