### PR TITLE
fix(datasets): select list-based channels with a native slice op so the array stays writeable

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -244,7 +244,7 @@ def test_list_channels_keep_the_array_writeable(tmp_path):
     prepare_ds(
         store,
         shape=(5, 4, 8, 8),
-        offset=(0, 0, 0),
+        offset=Coordinate(0, 0, 0),
         voxel_size=Coordinate(1, 1, 1),
         axis_names=["c^", "z", "y", "x"],
         dtype=np.uint8,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 import zarr
 from funlib.geometry import Coordinate
+from funlib.persistence import prepare_ds
 from pydantic import ValidationError
 
 from volara.datasets import LSD, Affs, Labels, Raw
@@ -227,3 +228,37 @@ def test_attrs_labels_lsd():
 
     lsd = LSD(store="dummy")
     assert lsd.attrs == {"lsds": True}
+
+
+def test_list_channels_keep_the_array_writeable(tmp_path):
+    """List-based `channels` must use a native slice op, not a callable.
+
+    funlib.persistence marks an array unwriteable as soon as a custom callable lazy
+    op is applied, so selecting channels with `lambda d: d[channels]` silently makes
+    every OUTPUT dataset unwritable -- the write then fails at block-process time,
+    not at config time.
+
+    pytest tests/test_dataset.py::test_list_channels_keep_the_array_writeable
+    """
+    store = tmp_path / "d.zarr" / "labels"
+    prepare_ds(
+        store,
+        shape=(5, 4, 8, 8),
+        offset=(0, 0, 0),
+        voxel_size=Coordinate(1, 1, 1),
+        axis_names=["c^", "z", "y", "x"],
+        dtype=np.uint8,
+        mode="w",
+    )[:] = np.arange(5 * 4 * 8 * 8, dtype=np.uint8).reshape(5, 4, 8, 8)
+
+    arr = Labels(store=store, channels=[[0, 2]]).array(mode="a")
+
+    # Correct selection...
+    expected = np.arange(5 * 4 * 8 * 8, dtype=np.uint8).reshape(5, 4, 8, 8)[[0, 2]]
+    assert arr.shape == expected.shape
+    np.testing.assert_array_equal(arr[:], expected)
+
+    # ...and still writeable, which a callable lazy op would have prevented.
+    assert arr.is_writeable
+    arr[:] = np.zeros_like(expected)
+    np.testing.assert_array_equal(arr[:], np.zeros_like(expected))

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -205,10 +205,6 @@ class Dataset(StrictBaseModel, ABC):
         if self.channels is not None:
             if isinstance(self.channels, list):
                 for channels in self.channels:
-                    # A native slice op, NOT `lambda d: d[channels]`: funlib.persistence
-                    # marks an array unwriteable as soon as a custom callable lazy op is
-                    # applied, and does not adjust the ROI/voxel_size for it. The trailing
-                    # comma makes this a 1-tuple index, i.e. select along the first axis.
                     arr.lazy_op(np.s_[channels,])
             else:
                 arr.lazy_op(np.s_[self.channels])

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -205,10 +205,11 @@ class Dataset(StrictBaseModel, ABC):
         if self.channels is not None:
             if isinstance(self.channels, list):
                 for channels in self.channels:
-                    if isinstance(channels, list):
-                        arr.lazy_op(lambda d: d[channels])
-                    else:
-                        arr.lazy_op(np.s_[channels])
+                    # A native slice op, NOT `lambda d: d[channels]`: funlib.persistence
+                    # marks an array unwriteable as soon as a custom callable lazy op is
+                    # applied, and does not adjust the ROI/voxel_size for it. The trailing
+                    # comma makes this a 1-tuple index, i.e. select along the first axis.
+                    arr.lazy_op(np.s_[channels,])
             else:
                 arr.lazy_op(np.s_[self.channels])
         return arr


### PR DESCRIPTION
First of the #31 redesign. **This one is not part of that feature at all — it is a live bug on `main`**,
found while auditing #31, and it is the root cause behind @pattonw's objection there. Standalone, targets
`main`.

## The bug

`Dataset.array()` selects list-based `channels` with a **callable**:

```python
for channels in self.channels:
    if isinstance(channels, list):
        arr.lazy_op(lambda d: d[channels])     # <- callable
    else:
        arr.lazy_op(np.s_[channels])           # <- native slice, two lines below
```

`funlib.persistence` marks an array **unwriteable** as soon as a custom callable lazy op is applied — and
does not adjust the ROI or `voxel_size` for it. So any dataset configured with a list-based `channels`
comes back unwriteable, and for an **output** dataset that surfaces at block-process time rather than at
config time.

## Reproduction

```python
import numpy as np, tempfile, os
from funlib.persistence import prepare_ds
from funlib.geometry import Coordinate

d = tempfile.mkdtemp()
def fresh(name, shape=(5, 4, 8, 8)):
    a = prepare_ds(os.path.join(d, name), shape=shape, offset=(0, 0, 0),
                   voxel_size=Coordinate(1, 1, 1), axis_names=["c^", "z", "y", "x"],
                   dtype=np.uint8, mode="a")
    a[:] = np.arange(np.prod(shape), dtype=np.uint8).reshape(shape)
    return a

a = fresh("a.zarr"); a.lazy_op(lambda x: x[[0, 2]])   # what main does
b = fresh("b.zarr"); b.lazy_op(np.s_[[0, 2],])        # what this PR does

print("same data:", np.array_equal(a[:], b[:]))
for name, arr in (("native slice", b), ("callable", a)):
    try:
        arr[:] = np.zeros_like(arr[:]); print(f"write via {name}: OK")
    except Exception as e:
        print(f"write via {name}: {type(e).__name__}: {e}")
```

```
same data: True
write via native slice: OK
write via callable: RuntimeError: This array is not writeable since you have applied a custom callable lazy op
```

Same shape, same bytes — identical to both the callable form and a direct numpy index — but writeable.

## Change

One line: `arr.lazy_op(lambda d: d[channels])` → `arr.lazy_op(np.s_[channels,])`. The trailing comma makes
it a 1-tuple index, i.e. select along the first axis, matching the scalar branch immediately below it.

It also removes a latent late-binding bug: the lambda captured the loop variable `channels` by reference.
`Array.lazy_op` applies eagerly so the *application* was correct, but the op stored in `Array.lazy_ops`
would have used the final value on any re-application.

## Tests

`test_list_channels_keep_the_array_writeable` asserts both halves — correct selection *and* that a write
succeeds:

```
$ pytest tests/test_dataset.py -q
9 passed                                    # this branch

$ pytest tests/test_dataset.py::test_list_channels_keep_the_array_writeable -q
1 failed                                    # with volara/datasets.py from main

$ pytest tests -q
164 passed, 3 skipped, 2 xfailed            # main is 163 passed; +1 is the new test
```

## Why this comes first

@pattonw's review on #31 said, of adding a general lambda field:

> *"If you submit a lambda function `lambda d: d[0]` does the same as sampling a channel, but does not
> adjust ROIs or voxel sizes etc. etc. which can lead to problems."*

That is exactly right, and it turns out `main` was already doing the thing he was warning against. Fixing
it here means the redesigned `lazy_op` field lands on a correct base instead of inheriting this. #31 is
being reopened as a chain on top of this — see the plan in that thread.
