### PR TITLE
fix(utils): give PydanticCallable a JSON schema so model_json_schema() works

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,12 @@
 from funlib.geometry import Coordinate, Roi
 from pydantic import ValidationError
 
-from volara.utils import PydanticCoordinate, PydanticRoi, StrictBaseModel
+from volara.utils import (
+    PydanticCallable,
+    PydanticCoordinate,
+    PydanticRoi,
+    StrictBaseModel,
+)
 
 
 class CoordinateModel(StrictBaseModel):
@@ -59,3 +64,26 @@ def test_strict_base_model_forbids_extra():
         assert False, "Should have raised"
     except ValidationError:
         pass
+
+
+def test_pydantic_callable_has_a_json_schema():
+    """A PydanticCallable field must not break `model_json_schema()`.
+
+    Without an explicit `__get_pydantic_json_schema__`, pydantic cannot derive a
+    schema from the plain-validator-function core schema and raises
+    PydanticInvalidForJsonSchema -- which takes the whole model with it, so any
+    task or dataset carrying a callable field becomes un-introspectable.
+
+    pytest tests/test_utils.py::test_pydantic_callable_has_a_json_schema
+    """
+
+    class M(StrictBaseModel):
+        fn: PydanticCallable | None = None
+
+    schema = M.model_json_schema()["properties"]["fn"]
+    # `fn` is optional, so the callable schema sits inside the anyOf.
+    variants = schema.get("anyOf", [schema])
+    callable_schema = next(v for v in variants if v.get("type") == "string")
+    assert callable_schema["format"] == "base64-cloudpickle"
+    # The unpickle-is-arbitrary-code caveat belongs where a schema consumer will see it.
+    assert "arbitrary code" in callable_schema["description"]

--- a/volara/utils.py
+++ b/volara/utils.py
@@ -123,6 +123,26 @@ class _CallablePydanticAnnotation:
             serialization=core_schema.plain_serializer_function_ser_schema(to_b64),
         )
 
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        _schema: core_schema.CoreSchema,
+        _handler: Any,
+    ) -> dict[str, Any]:
+        # Without this, `model_json_schema()` raises PydanticInvalidForJsonSchema on any
+        # model with a PydanticCallable field: pydantic cannot derive a schema from the
+        # plain-validator-function core schema above. Declaring it explicitly is both
+        # correct and accurate -- the JSON form of a PydanticCallable IS a base64 string
+        # (see to_b64/from_b64) -- and it keeps every task/dataset model introspectable.
+        return {
+            "type": "string",
+            "format": "base64-cloudpickle",
+            "description": (
+                "A python callable, serialized with cloudpickle and base64-encoded. "
+                "Deserializing executes arbitrary code: only load configs you trust."
+            ),
+        }
+
 
 PydanticCallable = Annotated[Callable, _CallablePydanticAnnotation]
 


### PR DESCRIPTION
Second of the #31 redesign, and — like #45 — **a pre-existing bug on `main`**, not part of the feature.
It is the reason #31's approach broke `model_json_schema()` for every `Dataset` subclass and 10 of the 12
blockwise task models: the defect is in `PydanticCallable` itself, and #31 merely widened its blast radius.

Fixing it here means the `lazy_op` field can be added later without taking model introspection with it.

## The bug

`_CallablePydanticAnnotation` (`volara/utils.py`) implements `__get_pydantic_core_schema__` but **not**
`__get_pydantic_json_schema__`. pydantic cannot derive a JSON schema from the
plain-validator-function core schema, so it raises — and that takes the whole enclosing model with it.

```python
from volara.utils import PydanticCallable, StrictBaseModel

class M(StrictBaseModel):
    fn: PydanticCallable | None = None

M.model_json_schema()
```

**On `main`:**
```
pydantic.errors.PydanticInvalidForJsonSchema: Cannot generate a JsonSchema for
core_schema.PlainValidatorFunctionSchema
```

**On this branch:**
```json
{"anyOf": [{"type": "string", "format": "base64-cloudpickle",
            "description": "A python callable, serialized with cloudpickle and base64-encoded. Deserializing executes arbitrary code: only load configs you trust."},
           {"type": "null"}],
 "default": null, "title": "Fn"}
```

This is live today, not hypothetical: **`LambdaTask.model_json_schema()` fails on `main`**, because
`LambdaTask.lambda_func` is a `PydanticCallable`.

## Change

Declare the JSON schema explicitly. It is accurate rather than a placeholder — the JSON form of a
`PydanticCallable` **is** a base64 string (see the existing `to_b64`/`from_b64`), so
`{"type": "string", "format": "base64-cloudpickle"}` describes it exactly.

The `description` carries the unpickle-is-arbitrary-code caveat. That warning currently exists only as a
comment inside `utils.py`; putting it in the schema is where a config-schema consumer will actually see
it. (Copilot raised this on #31 and it was never addressed — this is the smallest place to fix it.)

## One thing this does *not* fix

`LambdaTask.model_json_schema()` still fails after this, for a **second and unrelated** reason:

```
out_array_dtype   numpy.dtype | None   ->  PydanticSchemaGenerationError
```

`np.dtype` is an arbitrary type with only an isinstance schema. Different root cause, so it belongs in its
own change — I'd rather flag it than bundle it. Happy to follow up if you want it.

So the demonstration above uses a minimal model rather than `LambdaTask`, to isolate the half this PR
actually fixes.

## Tests

```
$ pytest tests/test_utils.py -q
8 passed

$ pytest tests -q
164 passed, 3 skipped, 2 xfailed
```

`test_pydantic_callable_has_a_json_schema` asserts the format *and* that the arbitrary-code caveat is
present, so the security note cannot be silently dropped later.
