### PR TITLE
test(logging): pin the worker-context log-basedir contract volara depends on

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,117 @@
+"""The log basedir has to reach a worker, and volara does not own the mechanism.
+
+volara spawns each worker as a fresh ``volara-cli`` PROCESS, so nothing that lives only in
+a module-global reaches it.  ``BlockwiseTask.process_blocks`` recovers the driver's basedir
+from ``daisy.Client().context["logdir"]`` (``volara/blockwise/blockwise.py:260``) -- i.e.
+volara depends on **daisy** to carry it across the boundary, in the ``DAISY_CONTEXT``
+environment variable.
+
+That dependency is load-bearing well beyond log placement: ``BlockwiseTask.meta_dir`` -- and
+therefore ``block_ds`` (``blocks_done.zarr``) -- lives under the basedir.  A driver and a
+worker that disagree about it address *different* done-marker stores, the worker's
+``open_ds(..., mode="a")`` creates a zarr Group where an Array is expected, and the run
+orphans **every** block while the driver log stays clean.
+
+It has already broken once: daisy v2 dropped ``logdir`` from the worker context and replaced
+it with a fallback that reads the process-global basedir -- correct for a *forked* worker,
+wrong for a spawned one.  Fixed upstream in funkelab/daisy@505e7be.
+
+There was no test in volara crossing a process boundary at all, which is why a change to
+someone else's contract could do that silently.  These tests pin the contract volara
+actually relies on, so the next change to it fails here instead of in a full-volume run.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import daisy
+import pytest
+
+from volara.logging import get_log_basedir, set_log_basedir
+
+
+def _context(**kwargs):
+    """A worker context as the driver builds it."""
+    return daisy.Context(hostname="localhost", port=1234, task_id="t", worker_id=0, **kwargs)
+
+
+def test_volara_set_log_basedir_reaches_the_daisy_context(tmp_path):
+    """The driver's basedir must appear in the context daisy hands to workers.
+
+    This is the assumption ``blockwise.py:260`` depends on. It is daisy's to provide, and
+    volara has no fallback if it stops -- so it is worth asserting from this side.
+
+    pytest tests/test_logging.py::test_volara_set_log_basedir_reaches_the_daisy_context
+    """
+    basedir = tmp_path / "driver_basedir"
+    set_log_basedir(basedir)
+    assert get_log_basedir() == basedir
+
+    # daisy stores the Path itself in the context object and stringifies it in to_env(),
+    # so compare as paths here and as strings in the serialized test below.
+    assert Path(_context()["logdir"]) == basedir, (
+        "daisy's worker context does not carry the driver's log basedir; every spawned "
+        "worker will resolve a different meta_dir and address a different blocks_done store"
+    )
+
+
+def test_the_basedir_survives_serialization_to_the_environment(tmp_path, monkeypatch):
+    """``logdir`` must survive the round-trip that actually crosses the boundary.
+
+    Being in the context object is not enough -- it reaches a worker only through
+    ``DAISY_CONTEXT``, so the encoded form is what matters.
+
+    pytest tests/test_logging.py::test_the_basedir_survives_serialization_to_the_environment
+    """
+    basedir = tmp_path / "driver_basedir"
+    set_log_basedir(basedir)
+
+    encoded = _context().to_env()
+    assert "logdir" in encoded, encoded
+
+    # from_env() is the only decoder daisy 1.x exposes, so go through the env var -- which
+    # is the real transport anyway.
+    monkeypatch.setenv(daisy.Context.ENV_VARIABLE, encoded)
+    assert Path(daisy.Context.from_env()["logdir"]) == basedir
+
+
+def test_a_spawned_process_recovers_the_drivers_basedir(tmp_path):
+    """A real child process must resolve the basedir its parent set.
+
+    The genuine cross-boundary check, and the one that was missing: a fresh interpreter
+    reading only ``DAISY_CONTEXT`` from its environment, exactly as ``volara-cli
+    blockwise-worker`` does.
+
+    pytest tests/test_logging.py::test_a_spawned_process_recovers_the_drivers_basedir
+    """
+    basedir = tmp_path / "driver_basedir"
+    set_log_basedir(basedir)
+
+    env = dict(os.environ)
+    env[daisy.Context.ENV_VARIABLE] = _context().to_env()
+    # Deliberately NOT inheriting the parent's module state: a fresh import, like a worker.
+    child = subprocess.run(
+        [sys.executable, "-c", "import daisy, json;"
+         " print(json.dumps(daisy.Context.from_env()['logdir']))"],
+        capture_output=True, text=True, env=env, check=True,
+    )
+    assert json.loads(child.stdout.strip()) == str(basedir), (
+        f"child resolved {child.stdout.strip()!r}, driver set {str(basedir)!r}"
+    )
+
+
+def test_a_worker_without_a_context_does_not_silently_guess(tmp_path, monkeypatch):
+    """With no ``DAISY_CONTEXT``, a worker must fail rather than invent a basedir.
+
+    Silently falling back to a default is what turns a misconfiguration into an
+    orphaned run with a clean driver log, so the loud failure is the desirable behaviour
+    and worth pinning.
+
+    pytest tests/test_logging.py::test_a_worker_without_a_context_does_not_silently_guess
+    """
+    monkeypatch.delenv(daisy.Context.ENV_VARIABLE, raising=False)
+    with pytest.raises(Exception):
+        daisy.Context.from_env()


### PR DESCRIPTION
**Tests only — no library change.** The remaining half of the closed #44.

## Why this is worth landing on its own

#44 proposed a volara-side `VOLARA_LOG_BASEDIR` guard. That is no longer needed: daisy fixed the root
cause upstream in `505e7be` *"Carry the log directory in the worker context, and adopt it in Client"* —
option 1 of the two proposed in [funkelab/daisy#75](https://github.com/funkelab/daisy/issues/75) — so
volara's worker adopts the basedir automatically via `daisy.Client()`.

What does **not** go away is the gap that let the bug ship: **volara had no test crossing a process
boundary at all.**

volara spawns each worker as a fresh `volara-cli` process and recovers the driver's basedir from
`daisy.Client().context["logdir"]` (`volara/blockwise/blockwise.py:260`). So volara depends on *daisy*
to carry it, and has no fallback if that stops. The dependency is load-bearing well beyond log
placement — `BlockwiseTask.meta_dir`, and therefore `block_ds` (`blocks_done.zarr`), lives under the
basedir. A driver and worker that disagree address **different** done-marker stores; the worker's
`open_ds(..., mode="a")` creates a zarr Group where an Array is expected; and the run **orphans every
block while the driver log stays clean.**

That is exactly what happened when daisy v2 replaced the context entry with a fallback that reads the
process-global basedir — correct for a *forked* worker, wrong for a *spawned* one. No exception, no
KeyError, just a plausible wrong path. It cost real full-volume runs before the cause was found.

Whichever side owns the fix, volara should be the one that notices when this contract changes.

## What the four tests pin

| | |
|---|---|
| `..._reaches_the_daisy_context` | the driver's basedir appears in the context daisy hands workers |
| `..._survives_serialization_to_the_environment` | it survives encoding into `DAISY_CONTEXT` — being in the object is not enough, that env var is the actual transport |
| `..._a_spawned_process_recovers_the_drivers_basedir` | **the real cross-boundary check** — a fresh interpreter inheriting nothing but the environment, exactly as `volara-cli blockwise-worker` does |
| `..._without_a_context_does_not_silently_guess` | an absent context fails loudly instead of inventing a default. Silently defaulting is what turns a misconfiguration into an orphaned run |

The third is the one that was missing.

## Verification

```
$ pytest tests/test_logging.py -q
4 passed

$ pytest tests -q
170 passed, 4 skipped, 2 xfailed        # main is 166 passed; +4 are these

$ ruff check tests/test_logging.py
All checks passed!
```

Run against **daisy 1.2.2**, which is what `main` resolves to since #42 capped `daisy<2` — so this is
the version CI will use. Two small API notes discovered while writing it, both documented in the file:
daisy 1.x stores `logdir` as a `PosixPath` in the context object and stringifies it in `to_env()`, and
`from_env()` is the only decoder 1.x exposes (no `from_env_string`).

## One thing these tests will do

They will **fail** against a daisy that stops carrying `logdir` — including daisy v2 before `505e7be`.
That is the intent. When volara moves to daisy 2.x as part of the migration, this file is the check that
the contract still holds rather than something to update to match.
