### PR TITLE
docs: move sphinx Makefile/make.bat to docs/ so `make html` works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/build/
 
 # PyBuilder
 .pybuilder/
@@ -162,7 +163,6 @@ cython_debug/
 #.idea/=
 
 .vscode
-docs/source/_build
 volara_logs
 uv.lock
 *.zarr

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,8 +5,8 @@
 # from the environment for the first two.
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     = .
-BUILDDIR      = _build
+SOURCEDIR     = source
+BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -7,8 +7,8 @@ REM Command file for Sphinx documentation
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
-set SOURCEDIR=.
-set BUILDDIR=_build
+set SOURCEDIR=source
+set BUILDDIR=build
 
 if "%1" == "" goto help
 


### PR DESCRIPTION
## Why

`docs/source/Makefile` and `docs/source/make.bat` were sitting **inside** the Sphinx source
directory with `SOURCEDIR = .` and `BUILDDIR = _build`. That produced two separate problems:

1. The conventional `make html` from `docs/` did nothing — there was no Makefile there.
2. A build that *did* work (run from `docs/source`) wrote its output to `docs/source/_build`,
   i.e. into the very tree Sphinx is reading.

This moves both drivers up to `docs/` and sets `SOURCEDIR = source` / `BUILDDIR = build`, which is
the layout `sphinx-quickstart` generates when you answer "yes" to separate source and build dirs —
and it lines `make html` up with the output path CI already uses (`docs/build/html`).

## What changed

- `docs/source/Makefile` → `docs/Makefile`, `SOURCEDIR = source`, `BUILDDIR = build`
- `docs/source/make.bat` → `docs/make.bat`, same two variables
- `.gitignore`: added `docs/build/` to the Sphinx section (previously only covered incidentally by
  the generic `build/` rule) and dropped the now-dead `docs/source/_build` entry

No `conf.py`, doc content, or workflow changes.

## The docs workflow is unaffected

`.github/workflows/docs.yaml` never invokes make. Its build step runs, from the repo root:

```
uv run --extra docs python -m ipykernel install --name volara_env --user
uv run --extra docs jupytext --to notebook examples/getting_started/basics.py
uv run --extra docs jupytext --to notebook examples/cremi/cremi.py
cp -r examples docs/source
uv run --extra docs sphinx-build docs/source docs/build/html -b html
```

and uploads `path: docs/build/html`. Because it passes source and build dirs explicitly to
`sphinx-build`, it does not care where `Makefile`/`make.bat` live. Verified below anyway.

## Verification

Built locally with `uv venv` + `uv pip install -e '.[docs]'` (CPython 3.11.15). This is a chore PR,
so there is no failing→passing unit test — but both symptoms are directly observable, so here is the
before/after. All output verbatim.

**Before (at `origin/main`) — `make html` from `docs/` does nothing:**

```
$ cd docs && ls -A
source
$ make html
make: *** No rule to make target 'html'.  Stop.
exit=2
```

**Before — the only build that worked put its output inside the source tree:**

```
$ cd docs/source && make -n html
sphinx-build -M html "." "_build"

$ make html    # tail
build succeeded, 25 warnings.

The HTML pages are in _build/html.

$ find docs -maxdepth 2 -name "_build" -o -maxdepth 2 -name "build"
docs/source/_build

$ ls -A docs/source
api.rst
_build          <-- build output now living in the source dir
cli.rst
conf.py
index.rst
install.rst
make.bat
Makefile
overview.rst
_static
tutorial.rst
```

**After — `make html` from `docs/` builds into `docs/build/html`:**

```
$ cd docs && make -n html
sphinx-build -M html "source" "build"

$ make html    # tail
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 26 warnings.

The HTML pages are in build/html.

$ ls -A docs
build
make.bat
Makefile
source

$ ls -A docs/build
doctrees
html
jupyter_execute

$ ls -A docs/build/html
api.html
.buildinfo
cli.html
conf.html
genindex.html
_images
index.html
install.html
objects.inv
overview.html
py-modindex.html
search.html
searchindex.js
_sources
_static
tutorial.html
```

(That first run reported 26 warnings because it was a cold build that also emitted an ipykernel
transport notice. The clean rebuild below reports 25, matching the base exactly.)

**Warning set is identical to the base — this change adds none:**

```
$ grep -c WARNING baseline-make-html.log   # docs/source layout, origin/main
21
$ grep -c WARNING after-make-html.log      # docs/ layout, this branch
21
$ diff <(grep WARNING baseline-make-html.log | <normalise abs paths> | sort) \
       <(grep WARNING after-make-html.log    | <normalise abs paths> | sort)
diff_exit=0
$ grep "build succeeded" baseline-make-html.log after-make-html.log
after-make-html.log:build succeeded, 25 warnings.
baseline-make-html.log:build succeeded, 25 warnings.
```

**CI's exact invocation still works on this branch:**

```
$ sphinx-build docs/source docs/build/html -b html    # tail
dumping object inventory... done
build succeeded, 25 warnings.

The HTML pages are in docs/build/html.

$ ls docs/build/html/index.html
docs/build/html/index.html
```

**Build output is gitignored:**

```
$ git status --short
 M .gitignore
A  docs/Makefile
A  docs/make.bat
 D docs/source/Makefile
 D docs/source/make.bat

$ git check-ignore -v docs/build/html/index.html
.gitignore:73:docs/build/	docs/build/html/index.html
```

The build did **not** need the committed CREMI zarr: the two notebook toctree entries
(`examples/cremi/cremi.ipynb`, `examples/getting_started/basics.ipynb`) are generated by CI's
jupytext step and are absent from a plain checkout, so they warn as `toc.not_readable` on both the
base and this branch. `tutorial.rst`'s `jupyter-sphinx` cells did execute in both builds.
