### PR TITLE
Drop unused wget and sphinx-material from the docs extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,14 @@ dev = [
 docs = [
     "autodoc_pydantic>=2.0",
     "sphinx-autodoc-typehints>=2.0",
-    "sphinx-material>=0.0.36",
     "sphinx-click>=6.0",
     "myst-parser>=4.0",
     "jupyter-sphinx>=0.5",
     "matplotlib>=3.0",
+    # pooch is currently unused, but deliberately retained: it is the intended
+    # mechanism for fetching the CREMI sample at docs-build time instead of
+    # tracking it in git (see issue #49). Do not sweep it as "unused".
     "pooch>=1.8",
-    "wget>=3.2",
     "funlib-show-neuroglancer>=0.2",
     "nbsphinx>=0.9.7",
     "jupytext>=1.16.7",


### PR DESCRIPTION
## What

Removes two dependencies from `[project.optional-dependencies] docs` in `pyproject.toml`:

- `wget>=3.2`
- `sphinx-material>=0.0.36`

## Why

Neither is used. `wget` has no importer anywhere in the repo, and the docs theme is
`pydata_sphinx_theme` — `sphinx_material` is neither the theme nor in the `extensions` list, so Sphinx
never loads it. They are dead weight that every contributor install and every CI docs job pays for: the
two of them drag in five further packages (`lxml`, `python-slugify`, `unidecode`, `text-unidecode`,
`css-html-js-minify`).

This is step 3 of the plan in #49, minus the `git rm --cached` — that part is a separate, larger change
and is deliberately not in this PR.

### `pooch>=1.8` is intentionally kept

`pooch` is *also* currently unused, but it must **not** be swept in a future "unused dependency" pass. It
is the intended mechanism for fetching the CREMI sample at docs-build time instead of tracking 776 MB of
zarr in git (#49). This PR adds a comment above it saying so, so the next person to grep for unused deps
finds the reason instead of re-deriving it.

## Verification

This is dependency hygiene, so there is no failing→passing MWE — nothing was broken before. Instead:
(1) grep proves the packages are unreferenced, (2) the resolution diff shows only removals, and (3) the
docs build is byte-identical with and without them.

### 1. Grep: both appear only in `pyproject.toml`

```
$ grep -rn --exclude-dir=.git -i 'wget' .
pyproject.toml:58:    "wget>=3.2",

$ grep -rn --exclude-dir=.git -iE 'sphinx[-_]material' .
pyproject.toml:52:    "sphinx-material>=0.0.36",
```

The theme is set to something else entirely (`docs/source/conf.py`):

```
$ grep -n 'html_theme\|^extensions\|"sphinx' docs/source/conf.py
32:extensions = [
34:    "sphinxcontrib.autodoc_pydantic",  # auto document pydantic models
35:    "sphinx.ext.autodoc",
36:    "sphinx.ext.napoleon",
37:    "sphinx_autodoc_typehints",
38:    "sphinx_click",  # auto document cli
61:html_theme = "pydata_sphinx_theme"
```

`pooch` is likewise only declared, never imported — which is exactly why the comment is needed:

```
$ grep -rn --exclude-dir=.git -i 'pooch' .
pyproject.toml:57:    "pooch>=1.8",
```

### 2. The docs extra still resolves; the diff is only removals

Compiled the full docs closure on `origin/main` and again on this branch:

```
$ uv pip compile --extra docs pyproject.toml -o base-docs.txt      # on origin/main
$ uv pip compile --extra docs pyproject.toml -o after-docs.txt     # on this branch
$ diff base-docs.txt after-docs.txt
29d28
< css-html-js-minify==2.5.5
96d94
< lxml==6.1.1
167d164
< python-slugify==8.0.4
187d183
< sphinx-material==0.0.36
196d191
< text-unidecode==1.3
207d201
< unidecode==1.4.0
211d204
< wget==3.2
```

Seven packages leave, nothing is added, and no version of any surviving package changes. The five extra
removals are reachable *only* through `sphinx-material` — per the baseline resolution's own provenance
annotations:

```
css-html-js-minify==2.5.5
    # via sphinx-material
lxml==6.1.1
    # via sphinx-material
python-slugify==8.0.4
    # via sphinx-material
sphinx-material==0.0.36
    # via volara (pyproject.toml)
text-unidecode==1.3
    # via python-slugify
unidecode==1.4.0
    # via python-slugify
wget==3.2
    # via volara (pyproject.toml)
```

Nothing in the repo imports any of them either:

```
$ grep -rn --exclude-dir=.git -iE '\b(lxml|unidecode|slugify|css_html_js_minify)\b' \
    --include='*.py' --include='*.rst' --include='*.md' --include='*.toml' --include='*.yaml' .
--- exit: 1 (1 = no matches) ---
```

### 3. The docs actually build, identically, without them

Installed this branch's docs extra and ran the real Sphinx build (notebook execution disabled, since
nbsphinx executes against the committed CREMI zarr and that is orthogonal to this change):

```
$ uv pip install -e '.[docs]'
$ python -c "import importlib.util as u; ..."
pydata_sphinx_theme    present=True
sphinx_material        present=False
wget                   present=False
pooch                  present=True

$ sphinx-build -b html docs/source build -D nbsphinx_execute=never
exit=0
build succeeded, 92 warnings.
```

Then reinstalled the two packages to reconstruct the pre-change environment and rebuilt. uv installed
precisely the seven packages the resolution diff predicted:

```
$ uv pip install 'sphinx-material>=0.0.36' 'wget>=3.2'
Resolved 32 packages in 8ms
Installed 7 packages in 14ms
 + css-html-js-minify==2.5.5
 + lxml==6.1.1
 + python-slugify==8.0.4
 + sphinx-material==0.0.36
 + text-unidecode==1.3
 + unidecode==1.4.0
 + wget==3.2

$ sphinx-build -b html docs/source build-base -D nbsphinx_execute=never
exit=0
build succeeded, 92 warnings.

$ diff <(grep WARNING base.log | sort) <(grep WARNING after.log | sort)
--- diff exit: 0 (0 = identical warnings)
```

Both builds succeed with 92 warnings and a byte-identical warning set, and no warning in either run
mentions `material`, `theme`, or `wget`. The packages contribute nothing to the build.

The 92 warnings are pre-existing and unrelated to this change — they are identical in both runs above,
one of which used the unmodified dependency set.

## Scope note

`pyproject.toml` only, 3 insertions / 2 deletions. No source, config, or CI change rides along.
