### PR TITLE
Rename volara.tmp to volara.segment_utils, keep a deprecating alias

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -23,7 +23,7 @@ Tutorial
     from skimage import data
     from skimage.filters import gaussian
 
-    from volara.tmp import seg_to_affgraph
+    from volara.segment_utils import seg_to_affgraph
 
     # Download the data
     cell_data = (data.cells3d().transpose((1, 0, 2, 3)) / 256).astype(np.uint8)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from funlib.persistence.arrays import prepare_ds
 
 from volara.dbs import SQLite
 from volara.logging import set_log_basedir
-from volara.tmp import seg_to_affgraph
+from volara.segment_utils import seg_to_affgraph
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_extract_frags.py
+++ b/tests/test_extract_frags.py
@@ -18,7 +18,7 @@ from scipy import ndimage
 from volara.blockwise import ExtractFrags
 from volara.datasets import Affs, Labels
 from volara.dbs import SQLite
-from volara.tmp import replace_values
+from volara.segment_utils import replace_values
 
 
 def make_task(affs_path, tmp_path, **kwargs) -> ExtractFrags:

--- a/tests/test_relabel.py
+++ b/tests/test_relabel.py
@@ -6,7 +6,7 @@ from funlib.geometry import Coordinate, Roi
 from volara.blockwise import Relabel
 from volara.datasets import Labels
 from volara.lut import LUT
-from volara.tmp import (
+from volara.segment_utils import (
     filter_mapping_to_block,
     prepare_mapping,
     replace_values,

--- a/tests/test_segment_utils.py
+++ b/tests/test_segment_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from volara.tmp import replace_values, seg_to_affgraph
+from volara.segment_utils import replace_values, seg_to_affgraph
 
 
 def test_seg_to_affgraph_2d():

--- a/tests/test_tmp_deprecated_alias.py
+++ b/tests/test_tmp_deprecated_alias.py
@@ -1,0 +1,58 @@
+"""The old ``volara.tmp`` path must keep working, but warn.
+
+``volara.tmp`` was renamed to ``volara.segment_utils``. The old name is baked into
+the published tutorial, so the alias has to stay importable for now.
+"""
+
+import importlib
+import sys
+
+import numpy as np
+import pytest
+
+import volara.segment_utils
+
+PUBLIC_NAMES = [
+    "filter_mapping_to_block",
+    "prepare_mapping",
+    "replace_values",
+    "replace_values_sorted",
+    "seg_to_affgraph",
+    "warmup_replace_values_sorted",
+]
+
+
+def _fresh_import():
+    """Import volara.tmp with a cold module cache so the warning fires."""
+    sys.modules.pop("volara.tmp", None)
+    return importlib.import_module("volara.tmp")
+
+
+def test_importing_old_path_warns():
+    with pytest.warns(DeprecationWarning, match="renamed to volara.segment_utils"):
+        _fresh_import()
+
+
+def test_old_path_reexports_are_the_same_objects():
+    with pytest.warns(DeprecationWarning):
+        tmp = _fresh_import()
+
+    for name in PUBLIC_NAMES:
+        assert getattr(tmp, name) is getattr(volara.segment_utils, name), name
+
+
+def test_old_path_still_computes():
+    """The aliased kernels are usable, not just importable."""
+    with pytest.warns(DeprecationWarning):
+        tmp = _fresh_import()
+
+    seg = np.array([[1, 1, 2, 2]] * 4, dtype=np.uint64)
+    affs = tmp.seg_to_affgraph(seg, nhood=[[1, 0], [0, 1]])
+    assert affs.shape == (2, 4, 4)
+    assert np.all(affs[1, :, 1] == 0)
+
+    arr = np.array([1, 2, 3, 99], dtype=np.int64)
+    result = tmp.replace_values(
+        arr, np.array([1, 2], dtype=np.int64), np.array([10, 20], dtype=np.int64)
+    )
+    np.testing.assert_array_equal(result, [10, 20, 3, 99])

--- a/volara/blockwise/extract_frags.py
+++ b/volara/blockwise/extract_frags.py
@@ -16,7 +16,7 @@ from skimage.morphology import remove_small_objects
 
 from ..datasets import Affs, Labels, Raw
 from ..dbs import PostgreSQL, SQLite
-from ..tmp import replace_values
+from ..segment_utils import replace_values
 from ..utils import PydanticCoordinate
 from .blockwise import BlockwiseTask
 

--- a/volara/blockwise/graph_mws.py
+++ b/volara/blockwise/graph_mws.py
@@ -13,7 +13,7 @@ from funlib.geometry import Coordinate, Roi
 from pydantic import Field
 
 from volara.lut import LUT, LUTS
-from volara.tmp import replace_values
+from volara.segment_utils import replace_values
 
 from ..dbs import PostgreSQL, SQLite
 from ..utils import PydanticCoordinate

--- a/volara/blockwise/relabel.py
+++ b/volara/blockwise/relabel.py
@@ -5,7 +5,7 @@ import numpy as np
 from funlib.geometry import Coordinate, Roi
 
 from volara.lut import LUT
-from volara.tmp import (
+from volara.segment_utils import (
     filter_mapping_to_block,
     prepare_mapping,
     replace_values_sorted,

--- a/volara/lut.py
+++ b/volara/lut.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 
-from volara.tmp import replace_values
+from volara.segment_utils import replace_values
 
 from .utils import StrictBaseModel
 

--- a/volara/segment_utils.py
+++ b/volara/segment_utils.py
@@ -1,0 +1,159 @@
+import numba
+import numpy as np
+
+
+def seg_to_affgraph(seg, nhood):
+    nhood = np.array(nhood)
+
+    # constructs an affinity graph from a segmentation
+    # assume affinity graph is represented as:
+    # shape = (e, z, y, x)
+    # nhood.shape = (edges, 3)
+    shape = seg.shape
+    nEdge = nhood.shape[0]
+    dims = nhood.shape[1]
+    aff = np.zeros((nEdge,) + shape, dtype=np.int32)
+
+    if dims == 2:
+        for e in range(nEdge):
+            aff[
+                e,
+                max(0, -nhood[e, 0]) : min(shape[0], shape[0] - nhood[e, 0]),
+                max(0, -nhood[e, 1]) : min(shape[1], shape[1] - nhood[e, 1]),
+            ] = (
+                (
+                    seg[
+                        max(0, -nhood[e, 0]) : min(shape[0], shape[0] - nhood[e, 0]),
+                        max(0, -nhood[e, 1]) : min(shape[1], shape[1] - nhood[e, 1]),
+                    ]
+                    == seg[
+                        max(0, nhood[e, 0]) : min(shape[0], shape[0] + nhood[e, 0]),
+                        max(0, nhood[e, 1]) : min(shape[1], shape[1] + nhood[e, 1]),
+                    ]
+                )
+                * (
+                    seg[
+                        max(0, -nhood[e, 0]) : min(shape[0], shape[0] - nhood[e, 0]),
+                        max(0, -nhood[e, 1]) : min(shape[1], shape[1] - nhood[e, 1]),
+                    ]
+                    > 0
+                )
+                * (
+                    seg[
+                        max(0, nhood[e, 0]) : min(shape[0], shape[0] + nhood[e, 0]),
+                        max(0, nhood[e, 1]) : min(shape[1], shape[1] + nhood[e, 1]),
+                    ]
+                    > 0
+                )
+            )
+
+    elif dims == 3:
+        for e in range(nEdge):
+            aff[
+                e,
+                max(0, -nhood[e, 0]) : min(shape[0], shape[0] - nhood[e, 0]),
+                max(0, -nhood[e, 1]) : min(shape[1], shape[1] - nhood[e, 1]),
+                max(0, -nhood[e, 2]) : min(shape[2], shape[2] - nhood[e, 2]),
+            ] = (
+                (
+                    seg[
+                        max(0, -nhood[e, 0]) : min(shape[0], shape[0] - nhood[e, 0]),
+                        max(0, -nhood[e, 1]) : min(shape[1], shape[1] - nhood[e, 1]),
+                        max(0, -nhood[e, 2]) : min(shape[2], shape[2] - nhood[e, 2]),
+                    ]
+                    == seg[
+                        max(0, nhood[e, 0]) : min(shape[0], shape[0] + nhood[e, 0]),
+                        max(0, nhood[e, 1]) : min(shape[1], shape[1] + nhood[e, 1]),
+                        max(0, nhood[e, 2]) : min(shape[2], shape[2] + nhood[e, 2]),
+                    ]
+                )
+                * (
+                    seg[
+                        max(0, -nhood[e, 0]) : min(shape[0], shape[0] - nhood[e, 0]),
+                        max(0, -nhood[e, 1]) : min(shape[1], shape[1] - nhood[e, 1]),
+                        max(0, -nhood[e, 2]) : min(shape[2], shape[2] - nhood[e, 2]),
+                    ]
+                    > 0
+                )
+                * (
+                    seg[
+                        max(0, nhood[e, 0]) : min(shape[0], shape[0] + nhood[e, 0]),
+                        max(0, nhood[e, 1]) : min(shape[1], shape[1] + nhood[e, 1]),
+                        max(0, nhood[e, 2]) : min(shape[2], shape[2] + nhood[e, 2]),
+                    ]
+                    > 0
+                )
+            )
+
+    else:
+        raise RuntimeError(f"AddAffinities works only in 2 or 3 dimensions, not {dims}")
+
+    return aff
+
+
+@numba.njit(parallel=True)
+def replace_values(arr, src, dst):
+    shape = arr.shape
+    arr = arr.ravel()
+    label_map = {src[i]: dst[i] for i in range(len(src))}
+    relabeled_arr = np.zeros_like(arr)
+
+    for i in numba.prange(arr.shape[0]):  # type: ignore[non-iterable]
+        relabeled_arr[i] = label_map.get(arr[i], arr[i])
+
+    return relabeled_arr.reshape(shape)
+
+
+def prepare_mapping(src, dst):
+    src = np.asarray(src, dtype=np.uint64)
+    dst = np.asarray(dst, dtype=np.uint64)
+
+    order = np.argsort(src)
+
+    return (
+        np.ascontiguousarray(src[order]),
+        np.ascontiguousarray(dst[order]),
+    )
+
+
+def filter_mapping_to_block(in_frags, src_sorted, dst_sorted):
+    block_ids = np.unique(in_frags)
+
+    idx = np.searchsorted(src_sorted, block_ids)
+
+    valid = idx < src_sorted.size
+    idx = idx[valid]
+    block_ids = block_ids[valid]
+
+    matched = src_sorted[idx] == block_ids
+
+    return (
+        np.ascontiguousarray(src_sorted[idx[matched]]),
+        np.ascontiguousarray(dst_sorted[idx[matched]]),
+    )
+
+
+@numba.njit(parallel=True)
+def replace_values_sorted(arr, src_sorted, dst_sorted):
+    shape = arr.shape
+    flat = arr.ravel()
+    out = np.empty_like(flat)
+
+    for i in numba.prange(flat.size):
+        v = flat[i]
+        j = np.searchsorted(src_sorted, v)
+
+        if j < src_sorted.size and src_sorted[j] == v:
+            out[i] = dst_sorted[j]
+        else:
+            out[i] = v
+
+    return out.reshape(shape)
+
+
+def warmup_replace_values_sorted():
+    _ = replace_values_sorted(
+        np.zeros((4, 4, 4), dtype=np.uint64),
+        np.array([0], dtype=np.uint64),
+        np.array([0], dtype=np.uint64),
+    )

--- a/volara/tmp.py
+++ b/volara/tmp.py
@@ -1,159 +1,40 @@
-import numba
-import numpy as np
+"""Deprecated alias for :mod:`volara.segment_utils`.
 
+This module was renamed to :mod:`volara.segment_utils` because ``tmp`` implied
+scratch code, while the contents are a load-bearing part of the public API
+(``seg_to_affgraph`` appears in the published tutorial, and the numba kernels are
+used throughout :mod:`volara.blockwise`).
 
-def seg_to_affgraph(seg, nhood):
-    nhood = np.array(nhood)
+Importing this module still works but emits a :class:`DeprecationWarning`.
+Update imports to::
 
-    # constructs an affinity graph from a segmentation
-    # assume affinity graph is represented as:
-    # shape = (e, z, y, x)
-    # nhood.shape = (edges, 3)
-    shape = seg.shape
-    nEdge = nhood.shape[0]
-    dims = nhood.shape[1]
-    aff = np.zeros((nEdge,) + shape, dtype=np.int32)
+    from volara.segment_utils import replace_values, seg_to_affgraph
+"""
 
-    if dims == 2:
-        for e in range(nEdge):
-            aff[
-                e,
-                max(0, -nhood[e, 0]) : min(shape[0], shape[0] - nhood[e, 0]),
-                max(0, -nhood[e, 1]) : min(shape[1], shape[1] - nhood[e, 1]),
-            ] = (
-                (
-                    seg[
-                        max(0, -nhood[e, 0]) : min(shape[0], shape[0] - nhood[e, 0]),
-                        max(0, -nhood[e, 1]) : min(shape[1], shape[1] - nhood[e, 1]),
-                    ]
-                    == seg[
-                        max(0, nhood[e, 0]) : min(shape[0], shape[0] + nhood[e, 0]),
-                        max(0, nhood[e, 1]) : min(shape[1], shape[1] + nhood[e, 1]),
-                    ]
-                )
-                * (
-                    seg[
-                        max(0, -nhood[e, 0]) : min(shape[0], shape[0] - nhood[e, 0]),
-                        max(0, -nhood[e, 1]) : min(shape[1], shape[1] - nhood[e, 1]),
-                    ]
-                    > 0
-                )
-                * (
-                    seg[
-                        max(0, nhood[e, 0]) : min(shape[0], shape[0] + nhood[e, 0]),
-                        max(0, nhood[e, 1]) : min(shape[1], shape[1] + nhood[e, 1]),
-                    ]
-                    > 0
-                )
-            )
+import warnings
 
-    elif dims == 3:
-        for e in range(nEdge):
-            aff[
-                e,
-                max(0, -nhood[e, 0]) : min(shape[0], shape[0] - nhood[e, 0]),
-                max(0, -nhood[e, 1]) : min(shape[1], shape[1] - nhood[e, 1]),
-                max(0, -nhood[e, 2]) : min(shape[2], shape[2] - nhood[e, 2]),
-            ] = (
-                (
-                    seg[
-                        max(0, -nhood[e, 0]) : min(shape[0], shape[0] - nhood[e, 0]),
-                        max(0, -nhood[e, 1]) : min(shape[1], shape[1] - nhood[e, 1]),
-                        max(0, -nhood[e, 2]) : min(shape[2], shape[2] - nhood[e, 2]),
-                    ]
-                    == seg[
-                        max(0, nhood[e, 0]) : min(shape[0], shape[0] + nhood[e, 0]),
-                        max(0, nhood[e, 1]) : min(shape[1], shape[1] + nhood[e, 1]),
-                        max(0, nhood[e, 2]) : min(shape[2], shape[2] + nhood[e, 2]),
-                    ]
-                )
-                * (
-                    seg[
-                        max(0, -nhood[e, 0]) : min(shape[0], shape[0] - nhood[e, 0]),
-                        max(0, -nhood[e, 1]) : min(shape[1], shape[1] - nhood[e, 1]),
-                        max(0, -nhood[e, 2]) : min(shape[2], shape[2] - nhood[e, 2]),
-                    ]
-                    > 0
-                )
-                * (
-                    seg[
-                        max(0, nhood[e, 0]) : min(shape[0], shape[0] + nhood[e, 0]),
-                        max(0, nhood[e, 1]) : min(shape[1], shape[1] + nhood[e, 1]),
-                        max(0, nhood[e, 2]) : min(shape[2], shape[2] + nhood[e, 2]),
-                    ]
-                    > 0
-                )
-            )
+from volara.segment_utils import (
+    filter_mapping_to_block,
+    prepare_mapping,
+    replace_values,
+    replace_values_sorted,
+    seg_to_affgraph,
+    warmup_replace_values_sorted,
+)
 
-    else:
-        raise RuntimeError(f"AddAffinities works only in 2 or 3 dimensions, not {dims}")
+__all__ = [
+    "filter_mapping_to_block",
+    "prepare_mapping",
+    "replace_values",
+    "replace_values_sorted",
+    "seg_to_affgraph",
+    "warmup_replace_values_sorted",
+]
 
-    return aff
-
-
-@numba.njit(parallel=True)
-def replace_values(arr, src, dst):
-    shape = arr.shape
-    arr = arr.ravel()
-    label_map = {src[i]: dst[i] for i in range(len(src))}
-    relabeled_arr = np.zeros_like(arr)
-
-    for i in numba.prange(arr.shape[0]):  # type: ignore[non-iterable]
-        relabeled_arr[i] = label_map.get(arr[i], arr[i])
-
-    return relabeled_arr.reshape(shape)
-
-
-def prepare_mapping(src, dst):
-    src = np.asarray(src, dtype=np.uint64)
-    dst = np.asarray(dst, dtype=np.uint64)
-
-    order = np.argsort(src)
-
-    return (
-        np.ascontiguousarray(src[order]),
-        np.ascontiguousarray(dst[order]),
-    )
-
-
-def filter_mapping_to_block(in_frags, src_sorted, dst_sorted):
-    block_ids = np.unique(in_frags)
-
-    idx = np.searchsorted(src_sorted, block_ids)
-
-    valid = idx < src_sorted.size
-    idx = idx[valid]
-    block_ids = block_ids[valid]
-
-    matched = src_sorted[idx] == block_ids
-
-    return (
-        np.ascontiguousarray(src_sorted[idx[matched]]),
-        np.ascontiguousarray(dst_sorted[idx[matched]]),
-    )
-
-
-@numba.njit(parallel=True)
-def replace_values_sorted(arr, src_sorted, dst_sorted):
-    shape = arr.shape
-    flat = arr.ravel()
-    out = np.empty_like(flat)
-
-    for i in numba.prange(flat.size):
-        v = flat[i]
-        j = np.searchsorted(src_sorted, v)
-
-        if j < src_sorted.size and src_sorted[j] == v:
-            out[i] = dst_sorted[j]
-        else:
-            out[i] = v
-
-    return out.reshape(shape)
-
-
-def warmup_replace_values_sorted():
-    _ = replace_values_sorted(
-        np.zeros((4, 4, 4), dtype=np.uint64),
-        np.array([0], dtype=np.uint64),
-        np.array([0], dtype=np.uint64),
-    )
+warnings.warn(
+    "volara.tmp has been renamed to volara.segment_utils. "
+    "Importing from volara.tmp is deprecated and the alias will be removed in a "
+    "future release; import from volara.segment_utils instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
## Why

`volara/tmp.py` was named like scratch code, but it is load-bearing public API:

- `seg_to_affgraph` is used by `tests/conftest.py` **and appears in the published tutorial** (`docs/source/tutorial.rst`), so it is user-facing.
- The numba kernels are imported across the package: `replace_values` by `volara/lut.py`, `volara/blockwise/graph_mws.py`, `volara/blockwise/extract_frags.py`; and `prepare_mapping`, `filter_mapping_to_block`, `replace_values_sorted`, `warmup_replace_values_sorted` by `volara/blockwise/relabel.py`.

A file called `tmp` signals "safe to delete". It isn't. This renames it to something honest.

## What

`volara/tmp.py` → **`volara/segment_utils.py`**. The name fits: all six public functions operate on segmentation label arrays — either converting a segmentation to an affinity graph, or remapping labels. (Alternatives considered: `relabel.py` collides with `volara/blockwise/relabel.py`; `numeric.py` / `kernels.py` describe the implementation rather than the domain.)

**The module body is a byte-identical move — no behaviour changed:**

```
$ git show origin/main:volara/tmp.py | diff - volara/segment_utils.py && echo "IDENTICAL (pure rename, zero content change)"
IDENTICAL (pure rename, zero content change)
```

All in-repo importers updated (7 Python files + the tutorial). `tests/test_tmp.py` → `tests/test_segment_utils.py`.

`volara/__init__.py`'s lazy `__getattr__` only lists `datasets` and `dbs`, so **it needed no update** — checked.

### The shim

`volara/tmp.py` stays as a thin alias that re-exports the same six objects and emits a `DeprecationWarning`, because the old path is baked into the published docs and possibly downstream code.

I grepped every repo under `/home/jeff/repos` for `volara.tmp` importers: **none found.** (`gunpowder-e11bio` has its own independent copy of `seg_to_affgraph` in `gunpowder/nodes/add_affinities.py` — unrelated to this module.) So the shim is defensive rather than strictly required, but the published tutorial alone justifies keeping it.

## Shim behaviour, demonstrated

This is a refactor, so there is no failing→passing bug reproduction. What needs demonstrating is that the old path still works *and* warns:

```python
import warnings
import numpy as np

with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter("always")
    from volara.segment_utils import seg_to_affgraph
print("new path volara.segment_utils -> warnings:", [str(x.message) for x in w])

with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter("always")
    import volara.tmp
print("old path volara.tmp -> warnings:")
for x in w:
    print(f"  {x.category.__name__}: {x.message}")

print("same object?", volara.tmp.seg_to_affgraph is seg_to_affgraph)
seg = np.array([[1, 1, 2, 2]] * 4, dtype=np.uint64)
print("volara.tmp.seg_to_affgraph works, shape:",
      volara.tmp.seg_to_affgraph(seg, nhood=[[1, 0], [0, 1]]).shape)
print("volara.tmp.replace_values works:",
      volara.tmp.replace_values(np.array([1, 2, 3, 99]),
                                np.array([1, 2]), np.array([10, 20])))
```

Real output on this branch:

```
new path volara.segment_utils -> warnings: []
old path volara.tmp -> warnings:
  DeprecationWarning: volara.tmp has been renamed to volara.segment_utils. Importing from volara.tmp is deprecated and the alias will be removed in a future release; import from volara.segment_utils instead.
same object? True
volara.tmp.seg_to_affgraph works, shape: (2, 4, 4)
volara.tmp.replace_values works: [10 20  3 99]
```

Note `same object? True` — the re-exports are the identical objects, so the numba dispatchers are shared, not recompiled. The new path emits no warning of its own.

`tests/test_tmp_deprecated_alias.py` locks this in: the old path warns, its six re-exports are the same objects as the new module's, and the aliased kernels still compute correctly.

## Verification

`ruff check volara tests` — clean before and after:

```
$ ruff check volara tests
All checks passed!
```

Full suite, base vs. this branch:

```
##### BASE (origin/main) #####
166 passed, 4 skipped, 2 xfailed, 7 warnings in 26.80s

##### AFTER (this branch) #####
169 passed, 4 skipped, 2 xfailed, 7 warnings in 24.37s
```

+3 = the three new shim tests. No warning-count change, confirming no in-repo importer was left on the deprecated path.

### Pre-existing issues found, NOT addressed here

Two things are red on `main` already and are out of scope for this PR:

1. **`ty` check fails on `main`.** CI runs `ty check volara tests` (`.github/workflows/ty.yaml`), which exits 1 with `Found 27 diagnostics` on `origin/main`. I confirmed the diagnostic set is *byte-identical* before and after this change, via a separate clean worktree at `origin/main`:

```
===== DIFF base vs after (empty = identical) =====
IDENTICAL ty diagnostics
```

2. **`tests/test_lambda_task.py::test_lambda_task_multiprocessing_local_worker` fails when the venv's `bin/` is not on `PATH`**, on base and on this branch identically, with `FileNotFoundError: [Errno 2] No such file or directory: 'volara-cli'`. The test shells out to the `volara-cli` console script but relies on ambient `PATH`. It passes once `.venv/bin` is on `PATH` (which is why the runs above show it green). Worth hardening separately to use `sys.executable -m` or an absolute script path.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
