### PR TITLE
chore: remove dead code

### DIFF
--- a/volara/blockwise/extract_frags.py
+++ b/volara/blockwise/extract_frags.py
@@ -223,9 +223,12 @@ class ExtractFrags(BlockwiseTask):
     def get_fragments(self, affs_data):
         fragments_data = self.compute_fragments(affs_data)
 
-        # # mask fragments if provided
-        # if mask is not None:
-        #     fragments_data *= mask_data.astype(np.uint64)
+        # TODO: also mask out the fragments themselves when a mask is provided.
+        # `process_block` currently applies the mask to the affinities before
+        # fragments are computed, so masked-out regions are only indirectly
+        # suppressed. Zeroing the fragments here (and skipping fully-masked
+        # blocks outright) is part of the generalized masking support tracked in
+        # https://github.com/e11bio/volara/issues/9
 
         # filter fragments
         if self.filter_fragments > 0:

--- a/volara/blockwise/pipeline.py
+++ b/volara/blockwise/pipeline.py
@@ -107,7 +107,6 @@ class Pipeline:
         try:
             with ExitStack() as stack:
                 task_map: dict[BlockwiseTask, daisy.Task] = {}
-                sinks = []
                 for node in node_ordering:
                     upstream_tasks = [
                         task_map[upstream]
@@ -118,8 +117,6 @@ class Pipeline:
                     )
                     task = stack.enter_context(task)
                     task_map[node] = task
-                    if spoof_graph.out_degree(node) == 0:
-                        sinks.append(task)
 
                 all_tasks = list(task_map.values())
 
@@ -146,7 +143,6 @@ class Pipeline:
             )
 
             task_map: dict[BlockwiseTask, daisy.Task] = {}
-            sinks = []
             for node in node_ordering:
                 upstream_tasks = [
                     task_map[upstream]
@@ -157,8 +153,6 @@ class Pipeline:
                 )
                 task = stack.enter_context(task)
                 task_map[node] = task
-                if self.task_graph.out_degree(node) == 0:
-                    sinks.append(task)
 
             all_tasks = list(task_map.values())
 

--- a/volara/logging.py
+++ b/volara/logging.py
@@ -9,20 +9,18 @@ daisy.logging.set_log_basedir(LOG_BASEDIR)
 
 def set_log_basedir(path: Path | str):
     """Set the base directory for logging (indivudal worker logs and detailed
-    task summaries). If set to ``None``, all logging will be shown on the
-    command line (which can get very messy).
+    task summaries). ``None`` is not a valid log directory and raises
+    ``TypeError``.
 
     Default is ``./volara_logs``.
     """
+    # Note: this coercion is what rejects ``None`` - ``Path(None)`` raises
+    # ``TypeError``, so the value below is always a real path.
     path = Path(path)
 
     global LOG_BASEDIR
 
-    if path is not None:
-        LOG_BASEDIR = Path(path)
-    else:
-        raise NotImplementedError("None is not a valid log directory")
-        LOG_BASEDIR = None
+    LOG_BASEDIR = path
 
     daisy.logging.set_log_basedir(LOG_BASEDIR)
 


### PR DESCRIPTION
## What

Removes three pieces of dead code. One category, one PR.

### 1. The `sinks` local in both `Pipeline` methods

`Pipeline.benchmark` and `Pipeline.run_blockwise` each built up a `sinks` list and then dropped it on the floor. Both methods hand `all_tasks` (every value in `task_map`) to `daisy.run_blockwise`/`server.run_blockwise`, so the out-degree check and the list it fed did nothing.

`sinks` occurs nowhere else in the repo — the only four hits were the two assignments and the two `.append`s that this PR deletes:

```
$ grep -rn "sinks" . --exclude-dir=.git
volara/blockwise/pipeline.py:110:                sinks = []
volara/blockwise/pipeline.py:122:                        sinks.append(task)
volara/blockwise/pipeline.py:149:            sinks = []
volara/blockwise/pipeline.py:161:                    sinks.append(task)
```

Worth noting `ruff` cannot catch this: `F841` (unused local) treats `sinks.append(task)` as a use, so `ruff check --select F841 volara tests` passes clean on base.

### 2. The commented-out mask block in `ExtractFrags.get_fragments`

This was the only commented-out code block in `volara/`. It referenced `mask`/`mask_data`, neither of which is in scope in `get_fragments`, so it could never have been uncommented as-is.

Rather than delete it, it is now a TODO pointing at #9 ("Generalized support for skipping masked out blocks"), which tracks the actual feature — the intent is preserved, the dead code is not. The TODO also records what happens today: `process_block` already applies the mask to the affinities *before* fragments are computed, so masked regions are indirectly suppressed; zeroing the fragments themselves and skipping fully-masked blocks is the #9 work.

### 3. `LOG_BASEDIR = None` in `volara/logging.py`

```python
    path = Path(path)
    global LOG_BASEDIR
    if path is not None:
        LOG_BASEDIR = Path(path)
    else:
        raise NotImplementedError("None is not a valid log directory")
        LOG_BASEDIR = None   # <- unreachable
```

`LOG_BASEDIR = None` is unreachable twice over. It sits after a `raise`, **and** the `else` that holds it can never be entered at all: `path = Path(path)` runs first, so a `None` argument dies with `TypeError` before the `if path is not None` check is ever evaluated. That guard is therefore always true and the `raise NotImplementedError` is itself unreachable. Verified on base, before any change:

```
$ python -c "import volara.logging as vl; vl.set_log_basedir(None)"
TypeError from Path(None) - else branch UNREACHABLE: expected str, bytes or os.PathLike object, not NoneType
```

Flattened to the assignment that actually runs. **Raise behaviour is unchanged** — `None` still raises `TypeError` from `Path(None)`, exactly as before; this PR does not make `None` valid and does not change which exception callers see.

The docstring is corrected in the same commit because it documented the dead branch's intended behaviour ("If set to `None`, all logging will be shown on the command line"), which has never been true. Leaving it would have left the file promising a feature whose only implementation was the code being removed. Flagging it explicitly since it is the one line here that is not a pure deletion.

No caller ever passes `None`: `LOG_BASEDIR` starts as `Path("./volara_logs")` and every `set_log_basedir` call site passes a path or a `str`.

## Why

`sinks` and `LOG_BASEDIR = None` are misleading to read — both look like they participate in the logic and neither does. The commented-out block was the last one in the package and its real feature already has an issue.

## Verification

Per the repo's PR standard, a chore PR gets no failing→passing MWE — there is no bug to reproduce, and the point of the change is that behaviour is identical. So instead, here is evidence that behaviour *is* identical.

Full suite, on this branch (`.venv/bin` on `PATH`, which `test_lambda_task_multiprocessing_local_worker` needs so its subprocess can find the `volara-cli` entry point):

```
$ pytest tests -q
166 passed, 4 skipped, 2 xfailed, 7 warnings in 24.94s
```

Identical to base (`b3c8ca6`): `166 passed, 4 skipped, 2 xfailed, 7 warnings in 25.54s`.

Lint and types, unchanged from base:

```
$ ruff check volara tests
All checks passed!

$ ruff format --check volara/logging.py volara/blockwise/pipeline.py volara/blockwise/extract_frags.py
3 files already formatted

$ ty check volara
Found 26 diagnostics
```

`ty` reports the same 26 pre-existing diagnostics on base and on this branch — none are in the touched lines.

### The suite does not actually cover the two methods I edited

`tests/test_pipeline.py` only exercises graph construction (`__add__`, `__or__`) and `drop()`. Nothing in the suite calls `Pipeline.run_blockwise` or `Pipeline.benchmark`, so "166 passed" is not by itself evidence that removing `sinks` is safe. I ran a two-task pipeline through `run_blockwise` directly, on base and on this branch:

```python
task1 = Threshold(in_data=Raw(store=raw_path), mask=Labels(store=mask1),
                  threshold=0.5, block_size=Coordinate(10, 10))
task2 = Threshold(in_data=Raw(store=raw_path), mask=Labels(store=mask2),
                  threshold=0.3, block_size=Coordinate(10, 10))
(task1 + task2).run_blockwise(multiprocessing=False)
```

This branch:

```
nodes: 2
edges: 1
mask1 matches data > 0.5: True
mask2 matches data > 0.3: True
mask1 nonzero count: 52 expected: 52
mask2 nonzero count: 76 expected: 76
RESULT: PASS
```

Base (`origin/main`, same script, same seed):

```
nodes: 2
edges: 1
mask1 matches data > 0.5: True
mask2 matches data > 0.3: True
mask1 nonzero count: 52 expected: 52
mask2 nonzero count: 76 expected: 76
RESULT: PASS
```

`set_log_basedir` before/after, on this branch:

```
default: PosixPath('volara_logs')
str arg -> PosixPath('some/dir')
Path arg -> PosixPath('other/dir')
None -> TypeError (unchanged): expected str, bytes or os.PathLike object, not NoneType
```

`Pipeline.benchmark` is not exercised here — it needs `spoof()` plumbing and writes a benchmark DB. Its `sinks` removal is character-identical to the `run_blockwise` one.

## On the "three other dead locals"

The cleanup note that prompted this PR mentioned three *other* dead locals in these two methods. I could not find three. An AST pass over both methods (every `Name` in `Store` context, checked against every `Name` ever loaded) turns up exactly one never-loaded local per method, and it is the same one both times: `_cl_monitor`.

```
=== benchmark (line 85) ===         === run_blockwise (line 142) ===
  ...                                 ...
  129  server        USED             168  server        USED
  130  _cl_monitor   NEVER-LOADED     169  _cl_monitor   NEVER-LOADED
```

**`_cl_monitor` is deliberately left alone.** It is already underscore-prefixed to mark it as an intentional side-effect binding, and `CLMonitor.__init__` → `ServerObserver.__init__` → `server.register_observer(self)` appends it to `server.observers`, a strong reference — so the object outlives the local regardless. Turning it into a bare `CLMonitor(server)` would save nothing and read like a mistake. Everything else in both methods (`log_basedir`, `benchmark_db_path`, `benchmark_logger`, `tmp_path`, `spoof_graph`, `node_ordering`, `task_map`, `upstream_tasks`, `task`, `all_tasks`, `server`) is genuinely read.
