### PR TITLE
fix(blockwise): make drop(drop_outputs=...) actually control output dropping

### DIFF
--- a/tests/test_blockwise_base.py
+++ b/tests/test_blockwise_base.py
@@ -71,6 +71,42 @@ def test_drop_removes_meta_dir(tmp_path):
     assert not t.meta_dir.exists()
 
 
+DROP_ARTIFACTS_CALLS: list[str] = []
+
+
+class RecordingTask(DummyTask):
+    """DummyTask that records every ``drop_artifacts`` call."""
+
+    def drop_artifacts(self):
+        DROP_ARTIFACTS_CALLS.append(self.task_name)
+
+
+def test_drop_calls_drop_artifacts_by_default(tmp_path):
+    """drop() is a full reset: meta dir removed and outputs dropped."""
+    from volara.logging import set_log_basedir
+
+    set_log_basedir(tmp_path / "logs")
+    DROP_ARTIFACTS_CALLS.clear()
+    t = RecordingTask()
+    t.meta_dir.mkdir(parents=True)
+    t.drop()
+    assert not t.meta_dir.exists()
+    assert DROP_ARTIFACTS_CALLS == [t.task_name]
+
+
+def test_drop_outputs_false_skips_drop_artifacts(tmp_path):
+    """drop(drop_outputs=False) clears the meta dir but keeps the outputs."""
+    from volara.logging import set_log_basedir
+
+    set_log_basedir(tmp_path / "logs")
+    DROP_ARTIFACTS_CALLS.clear()
+    t = RecordingTask()
+    t.meta_dir.mkdir(parents=True)
+    t.drop(drop_outputs=False)
+    assert not t.meta_dir.exists()
+    assert DROP_ARTIFACTS_CALLS == []
+
+
 def test_init_block_array(tmp_path):
     from volara.logging import set_log_basedir
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -77,3 +77,36 @@ def test_pipeline_drop(zarr_2d, tmp_path):
     pipeline.drop()
     assert not mask1_path.exists()
     assert not mask2_path.exists()
+
+
+def test_pipeline_drop_outputs_false(zarr_2d, tmp_path):
+    """Pipeline.drop forwards drop_outputs to every task."""
+    raw_path, _ = zarr_2d
+    mask1_path = tmp_path / "test.zarr" / "mask1"
+    mask2_path = tmp_path / "test.zarr" / "mask2"
+
+    task1 = Threshold(
+        in_data=Raw(store=raw_path),
+        mask=Labels(store=mask1_path),
+        threshold=0.5,
+        block_size=Coordinate(10, 10),
+    )
+    task2 = Threshold(
+        in_data=Raw(store=raw_path),
+        mask=Labels(store=mask2_path),
+        threshold=0.3,
+        block_size=Coordinate(10, 10),
+    )
+
+    for task in (task1, task2):
+        task.init()
+        task.init_block_array()
+    assert mask1_path.exists()
+    assert mask2_path.exists()
+
+    pipeline = task1 + task2
+    pipeline.drop(drop_outputs=False)
+    assert mask1_path.exists()
+    assert mask2_path.exists()
+    assert not task1.meta_dir.exists()
+    assert not task2.meta_dir.exists()

--- a/tests/test_threshold.py
+++ b/tests/test_threshold.py
@@ -23,6 +23,32 @@ def test_threshold_init_and_drop(zarr_2d, tmp_path):
     assert not mask_path.exists()
 
 
+def test_threshold_drop_outputs_false_keeps_output(zarr_2d, tmp_path):
+    """drop(drop_outputs=False) resets the block-done cache but keeps the output.
+
+    drop() with the default (True) still deletes it.
+    """
+    raw_path, _ = zarr_2d
+    mask_path = tmp_path / "test.zarr" / "mask"
+    task = Threshold(
+        in_data=Raw(store=raw_path),
+        mask=Labels(store=mask_path),
+        threshold=0.5,
+        block_size=Coordinate(10, 10),
+    )
+    task.init()
+    task.init_block_array()
+    assert mask_path.exists()
+    assert task.block_ds.exists()
+
+    task.drop(drop_outputs=False)
+    assert mask_path.exists(), "drop_outputs=False must not delete the output"
+    assert not task.meta_dir.exists()
+
+    task.drop()
+    assert not mask_path.exists()
+
+
 def test_threshold_basic(zarr_2d, block_2d, tmp_path):
     """Threshold at 0.5 produces correct binary mask."""
     raw_path, data = zarr_2d

--- a/volara/blockwise/blockwise.py
+++ b/volara/blockwise/blockwise.py
@@ -168,16 +168,26 @@ class BlockwiseTask(StrictBaseModel, ABC):
         process_block = self.process_block_func()
         process_block(block)
 
-    def drop(self, drop_outputs: bool = False) -> None:
+    def drop(self, drop_outputs: bool = True) -> None:
         """
         A helper function to drop any artifacts produced by a task
         and return to a state identical to before having executed the
         task.
+
+        Args:
+            drop_outputs: whether to also delete this task's outputs via
+                :meth:`drop_artifacts`. ``True`` (the default) is the full reset
+                described above, and is what ``drop()`` has always done. Pass
+                ``False`` to clear only the meta directory -- the worker logs and
+                the block-done cache -- which forces every block to be recomputed
+                on the next run while leaving the existing outputs (datasets, dbs,
+                luts) in place to be overwritten block by block.
         """
         # reset the blocks_done ds so that the task is rerun
         if self.meta_dir.exists():
             rmtree(self.meta_dir)
-        self.drop_artifacts()
+        if drop_outputs:
+            self.drop_artifacts()
 
     def check_block_func(self):
         """

--- a/volara/blockwise/pipeline.py
+++ b/volara/blockwise/pipeline.py
@@ -169,6 +169,11 @@ class Pipeline:
                 _cl_monitor = daisy.cl_monitor.CLMonitor(server)  # type: ignore[unresolved-attribute]
                 server.run_blockwise(all_tasks)
 
-    def drop(self):
+    def drop(self, drop_outputs: bool = True):
+        """
+        Drop every task in the pipeline. ``drop_outputs`` is forwarded to
+        :meth:`BlockwiseTask.drop`; pass ``False`` to reset only the block-done
+        caches and logs and keep the tasks' outputs.
+        """
         for task in self.task_graph.nodes():
-            task.drop()
+            task.drop(drop_outputs=drop_outputs)


### PR DESCRIPTION
## Why

`BlockwiseTask.drop` has taken a `drop_outputs` argument since the initial commit and has
never read it:

```python
def drop(self, drop_outputs: bool = False) -> None:
    if self.meta_dir.exists():
        rmtree(self.meta_dir)
    self.drop_artifacts()          # unconditional
```

`drop_outputs` appears exactly once in the repo — its own definition. So a caller passing
`drop_outputs=False` was silently ignored (worse than a `TypeError`), and `Pipeline.drop`
never forwarded it at all.

**One correction to the framing of this bug:** `drop()` is *not* "meta dir only" today.
Every concrete task implements `drop_artifacts()` as "delete what I wrote"
(`Threshold.drop_artifacts -> self.mask.drop()`, `Argmax -> self.sem_data.drop()`,
`ExtractFrags -> self.frags_data.drop(); self.db.drop()`, …), so **dropping the outputs is
already the unconditional behaviour of `drop()`** — asserted by
`tests/test_pipeline.py::test_pipeline_drop`, relied on by `BlockwiseTask.benchmark()` /
`Pipeline.benchmark()` for spoof cleanup, and documented in
`examples/getting_started/basics.py`.

That means the parameter cannot be implemented as "drop outputs when `True`" while keeping
the default `False` — that would silently *remove* output dropping from every existing
`drop()` caller. Evidence (the literal reading, `if drop_outputs: self.drop_artifacts()`
with the default left at `False`):

```
$ python -m pytest tests/ -q --no-header -p no:randomly
FAILED tests/test_lambda_task.py::test_lambda_task_multiprocessing_local_worker
FAILED tests/test_pipeline.py::test_pipeline_drop - AssertionError: assert no...
2 failed, 164 passed, 4 skipped, 2 xfailed, 7 warnings in 24.25s
```

(`test_lambda_task_multiprocessing_local_worker` fails identically on `main` — see below.)

## What this does

Gate `drop_artifacts()` on the flag and **default it to `True`**, so:

* `drop()` — unchanged from today: remove the meta dir (logs + block-done cache) **and**
  drop the outputs. No existing caller changes behaviour.
* `drop(drop_outputs=False)` — now means what it says: clear only the meta dir so every
  block is recomputed on the next run, leaving the existing outputs in place to be
  overwritten block by block.
* `Pipeline.drop(drop_outputs=...)` forwards the flag (it previously accepted no arguments).

The declared default flips `False -> True`, which makes the signature honest: `False` never
behaved like `False`. No caller's behaviour regresses — `drop()` and `drop(drop_outputs=True)`
are exactly what they were, and only `drop(drop_outputs=False)`, which was silently ignored,
changes.

## Runnable example

`repro_drop_outputs.py` (not committed — the same behaviour is covered by the tests below):

```python
import tempfile
from pathlib import Path

import numpy as np
from funlib.geometry import Coordinate
from funlib.persistence import prepare_ds

from volara.blockwise import Threshold
from volara.datasets import Labels, Raw
from volara.logging import set_log_basedir


def make_task(tmp: Path, name: str) -> Threshold:
    raw_path = tmp / "test.zarr" / "raw"
    arr = prepare_ds(
        raw_path, shape=(10, 10), voxel_size=Coordinate(1, 1), dtype=np.float32, mode="w"
    )
    arr[:] = np.random.default_rng(0).random((10, 10), dtype=np.float32)
    return Threshold(
        in_data=Raw(store=raw_path),
        mask=Labels(store=tmp / "test.zarr" / name),
        threshold=0.5,
        block_size=Coordinate(10, 10),
    )


for kwargs in [{"drop_outputs": False}, {}]:
    with tempfile.TemporaryDirectory() as tmpdir:
        tmp = Path(tmpdir)
        set_log_basedir(tmp / "logs")
        task = make_task(tmp, f"mask_{len(kwargs)}")
        task.init()
        task.meta_dir.mkdir(parents=True, exist_ok=True)
        assert task.mask.store.exists(), "output was not created by init()"

        task.drop(**kwargs)

        print(f"task.drop({', '.join(f'{k}={v}' for k, v in kwargs.items())})")
        print(f"  output dataset still exists: {task.mask.store.exists()}")
        print(f"  meta dir still exists:       {task.meta_dir.exists()}")
```

Real output, before and after, in one run (`git stash` / `git stash pop` around the library
change):

```
$ echo "=== BEFORE (origin/main, b3c8ca6) ===" && git stash --quiet && python repro_drop_outputs.py; git stash pop --quiet && echo "=== AFTER (this branch) ===" && python repro_drop_outputs.py
=== BEFORE (origin/main, b3c8ca6) ===
task.drop(drop_outputs=False)
  output dataset still exists: False
  meta dir still exists:       False
task.drop()
  output dataset still exists: False
  meta dir still exists:       False
=== AFTER (this branch) ===
task.drop(drop_outputs=False)
  output dataset still exists: True
  meta dir still exists:       False
task.drop()
  output dataset still exists: False
  meta dir still exists:       False
```

Before: the argument is ignored and the output zarr is deleted either way. After:
`drop_outputs=False` keeps the output, `drop()` still deletes it.

## Tests

Three new tests. Against the base library code (tests stashed in, `volara/` stashed out):

```
$ git stash --quiet -- volara && python -m pytest tests/test_blockwise_base.py::test_drop_outputs_false_skips_drop_artifacts tests/test_threshold.py::test_threshold_drop_outputs_false_keeps_output tests/test_pipeline.py::test_pipeline_drop_outputs_false -q --no-header -p no:randomly
FAILED tests/test_blockwise_base.py::test_drop_outputs_false_skips_drop_artifacts
FAILED tests/test_threshold.py::test_threshold_drop_outputs_false_keeps_output
FAILED tests/test_pipeline.py::test_pipeline_drop_outputs_false - TypeError: ...
3 failed, 2 warnings in 0.75s
```

With the fix (plus the two tests pinning the unchanged default behaviour):

```
$ python -m pytest tests/test_blockwise_base.py::test_drop_outputs_false_skips_drop_artifacts tests/test_blockwise_base.py::test_drop_calls_drop_artifacts_by_default tests/test_threshold.py::test_threshold_drop_outputs_false_keeps_output tests/test_pipeline.py::test_pipeline_drop_outputs_false tests/test_pipeline.py::test_pipeline_drop -q --no-header -p no:randomly
5 passed, 2 warnings in 0.66s
```

Full suite, `origin/main` (b3c8ca6) then this branch:

```
$ python -m pytest tests/ -q --no-header -p no:randomly     # origin/main
FAILED tests/test_lambda_task.py::test_lambda_task_multiprocessing_local_worker
1 failed, 165 passed, 4 skipped, 2 xfailed, 7 warnings in 24.00s

$ python -m pytest tests/ -q --no-header -p no:randomly     # this branch
FAILED tests/test_lambda_task.py::test_lambda_task_multiprocessing_local_worker
1 failed, 169 passed, 4 skipped, 2 xfailed, 7 warnings in 25.63s
```

`test_lambda_task_multiprocessing_local_worker` is a pre-existing failure on `main`,
unrelated to this change.

`ruff check volara tests` passes. `ty check volara tests` reports 27 diagnostics on both
`main` and this branch (no new ones); `ruff format --check` wants to reformat
`tests/test_lambda_task.py` and `volara/__init__.py` on both — neither is touched here.

## Notes / things deliberately left out

* **A second, additive reading was rejected.** `drop_outputs=True` could instead have meant
  "also drop `self.output_datasets`", i.e. drop the outputs that `drop_artifacts()`
  deliberately preserves (`LambdaTask` with `init_out=False`; the DB tasks that only call
  `drop_edges()`). That is unsafe today: `ApplyShift.output_datasets` returns
  `[self.shifts]`, which is an **input** it reads shifts from — its actual outputs are
  `aligned` / `interp_shifts`, as its own `drop_artifacts` shows. Wiring `drop_outputs` to
  `output_datasets` would therefore have deleted an upstream task's data. Reported
  separately rather than fixed here.
* `output_datasets` is defined on 10 task classes and read by nothing in the library (only
  `tests/test_lambda_task.py`), and is missing entirely on `ExtractFrags`, the `graph_mws`
  tasks and `CLAHE`. Untouched here.
