### PR TITLE
fix(examples): point benchmark_cremi.py at the cremi data directory

### DIFF
--- a/examples/benchmarks/benchmark_cremi.py
+++ b/examples/benchmarks/benchmark_cremi.py
@@ -12,7 +12,9 @@ from volara.datasets import Affs, Labels, Raw
 from volara.dbs import SQLite
 from volara.lut import LUT
 
-os.chdir(Path(__file__).parent)
+# The CREMI volume this benchmark reads lives with the cremi example, not here,
+# and every store below is named relative to it.
+os.chdir(Path(__file__).parent.parent / "cremi")
 print(Path.cwd())
 
 raw = Raw(store="sample_A+_20160601.zarr/raw", scale_shift=(1 / 255, 0), writable=False)  # type: ignore[arg-type]


### PR DESCRIPTION
## Why

`examples/benchmarks/benchmark_cremi.py` chdirs into its own directory and then
opens `sample_A+_20160601.zarr/raw`, `.../affs`, `.../fragments.db` and so on.
That zarr is committed under `examples/cremi/`, not `examples/benchmarks/`:

```
$ git ls-tree -r --name-only origin/main -- examples/ | grep -E 'benchmark_cremi|zarr/\.zgroup'
examples/benchmarks/benchmark_cremi.py
examples/cremi/sample_A+_20160601.zarr/.zgroup
```

So the script cannot run as committed. It dies on its fourth statement, before a
single task is constructed. This PR chdirs into `examples/cremi` instead, which
is the directory every store name in the file is written relative to (they were
copied verbatim from `examples/cremi/cremi.py`).

## Before / after

Same command both times: `cd examples/benchmarks && python benchmark_cremi.py`.

**Before — origin/main (b3c8ca6):** dies at line 19.

```
/tmp/claude-1001/wk-bench-a-3b62ebf0/examples/benchmarks
Traceback (most recent call last):
  File "/tmp/claude-1001/wk-bench-a-3b62ebf0/examples/benchmarks/benchmark_cremi.py", line 19, in <module>
    affs = Affs(store="sample_A+_20160601.zarr/affs", writable=False)  # type: ignore[arg-type]
  File "/home/jeff/repos/volara/.venv/lib/python3.13/site-packages/pydantic/main.py", line 263, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for Affs
  Value error, Affs(..., neighborhood=?)
neighborhood must be provided when referencing an array that does not yet exist
 [type=value_error, input_value={'store': 'sample_A+_2016...ffs', 'writable': False}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.13/v/value_error
```

(`Affs` derives its neighborhood from the array's attrs, so a store that isn't
there surfaces as "array does not yet exist".)

**After — this branch:** the volume resolves. `raw` and `affs` open, `block_size`
is read off the raw chunks, and all four tasks (lines 20-86) are constructed. The
run now reaches `pipeline.benchmark(...)` on line 87 and fails inside `spoof`:

```
/tmp/claude-1001/wk-bench-a-3b62ebf0/examples/cremi
Traceback (most recent call last):
  File "/tmp/claude-1001/wk-bench-a-3b62ebf0/examples/benchmarks/benchmark_cremi.py", line 87, in <module>
    pipeline.benchmark(multiprocessing=True)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/claude-1001/wk-bench-a-3b62ebf0/volara/blockwise/pipeline.py", line 101, in benchmark
    spoof_graph = nx.relabel_nodes(
        self.task_graph,
        lambda x: x.spoof(tmp_path),
    )
  ...
  File "/tmp/claude-1001/wk-bench-a-3b62ebf0/volara/blockwise/blockwise.py", line 416, in spoof
    data[name] = value.spoof(spoof_dir)
                 ~~~~~~~~~~~^^^^^^^^^^^
  File "/tmp/claude-1001/wk-bench-a-3b62ebf0/volara/dbs.py", line 208, in spoof
    graph_provider = self.open("r")
  ...
  File "/home/jeff/repos/volara/.venv/lib/python3.13/site-packages/funlib/persistence/graphs/sql_graph_database.py", line 90, in __init__
    raise RuntimeError("metadata does not exist, can't open in read mode")
RuntimeError: metadata does not exist, can't open in read mode
```

I then created `fragments.db` by hand (`SQLite(...).init()`, i.e. what running
`examples/cremi/cremi.py` first would do) to see whether that was the only thing
left. It isn't — the next blocker is immediately behind it:

```
  File "/tmp/claude-1001/wk-bench-a-3b62ebf0/volara/blockwise/blockwise.py", line 416, in spoof
    data[name] = value.spoof(spoof_dir)
  File "/tmp/claude-1001/wk-bench-a-3b62ebf0/volara/datasets.py", line 125, in spoof
    raise ValueError(f"Not spoofing dataset: store {self.store} is not a Path")
ValueError: Not spoofing dataset: store sample_A+_20160601.zarr/affs is not a Path
```

## Honest scope

**This PR does not make the example run end to end.** It fixes the path defect
only, and I did not fold in the two further blockers it exposed, because both are
in `volara/` and are a different bucket from "the example points at the wrong
folder":

1. `SQLite.spoof` is declared `spoof(self, nodes: bool = True)` while
   `BlockwiseTask.spoof` calls `value.spoof(spoof_dir)`. The spoof *directory* is
   therefore passed as `nodes`, is always truthy, and the source db is always
   opened `"r"` — hence `metadata does not exist` on any checkout where
   `fragments.db` was never created. The spoofed db is also written next to the
   original rather than into the spoof dir.
2. `Dataset.spoof` (`volara/datasets.py:125`) rejects `str` stores, but `store`
   is typed `Path | str` and *both* CREMI examples use the string form (with
   `# type: ignore[arg-type]`). Any benchmark of a string-store task stops here.
   Changing the example to `Path(...)` would work around it, but would also
   diverge from the sibling `examples/cremi/cremi.py` for a library-side gap.

Note also that `Pipeline.benchmark` currently records nothing at all — that is
fixed separately in #56, which is where a run that gets past
`spoof` would produce a non-empty report.

## Skeptical pass

One statement changed, plus a comment saying why. No library code, no
dependencies, no test changes — there is no test harness for `examples/`, and the
evidence above is the before/after run of the example itself.
