### PR TITLE
feat(benchmark): trace normal runs, and drop sqlite and polars from the benchmark path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "scipy>=1.15.3",
     "scikit-image>=0.25.2",
     "cloud-volume>=12.4.1",
-    "polars>=1.31.0",
     "cloudpickle>=3.0",
     "psutil>=7.0.0",
     # not a direct dependency, but we have to specify

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -88,6 +88,38 @@ def test_benchmark_records_traces(tiny_task):
         assert "Process Block" in report.read_text()
 
 
+def test_benchmark_twice_in_one_process(tiny_task):
+    """Two benchmark() calls in one interpreter must both work.
+
+    Regression test: ``benchmark_run`` wipes ``volara_benchmark_logs/traces`` at the start of every
+    run, but ``_process_trace_file`` caches its handle on ``(pid, trace_dir)``. On a second call
+    both still matched, so the cache hit skipped the ``mkdir`` and returned a path whose directory
+    had just been removed — the first append raised ``FileNotFoundError`` and the report came back
+    empty. Every other test gets a fresh ``tmp_path`` cwd, so none of them hit the cache.
+
+    pytest tests/test_benchmark.py::test_benchmark_twice_in_one_process
+    """
+    tiny_task().benchmark(multiprocessing=False)
+    first = traced_operations()
+    assert len(first) > 0, "the first benchmark() recorded nothing"
+
+    # same interpreter, same cwd -> same (pid, trace_dir) cache key as the run above
+    tiny_task().benchmark(multiprocessing=False)
+    second = traced_operations()
+
+    assert len(second) > 0, "the second benchmark() in one process recorded nothing"
+    assert "init" in {operation for _, operation in second}
+
+    # The report must be this run's, written fresh -- the bug left the trace directory missing, so
+    # print_report found nothing and said "No benchmark data available".
+    report = Path("volara_benchmark_report") / "time.csv"
+    assert report.exists() and report.read_text().strip(), "the second run wrote no report"
+
+    # Not asserted: that both runs record the same operations. They do not, and correctly so -- the
+    # first run marks the blocks done, so the second honours that cache and skips them. That is
+    # `test_benchmark_runs_the_task_for_real`'s territory, not this test's.
+
+
 def test_benchmark_runs_the_task_for_real(tiny_task):
     """The default benchmark path is an ordinary run, not a dry run.
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,285 @@
+import multiprocessing
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from funlib.geometry import Coordinate
+from funlib.persistence import open_ds
+from funlib.persistence.arrays import prepare_ds
+
+from volara.blockwise import LambdaTask
+from volara.blockwise.benchmark import (
+    BENCHMARK_DIR_ENV_VAR,
+    BenchmarkLogger,
+    benchmarking,
+    get_benchmark_dir,
+    read_traces,
+)
+from volara.datasets import Labels, Raw
+from volara.workers import LocalWorker
+
+# benchmark() writes its traces, spoofed inputs and report relative to the cwd
+TRACE_DIR = Path("volara_benchmark_logs/traces")
+
+
+@pytest.fixture()
+def tiny_task(tmp_path, monkeypatch):
+    """A 20x10 -> 2 block LambdaTask, with the cwd moved into tmp_path.
+
+    The input is declared ``writable=False`` so that ``spoof`` symlinks it
+    instead of expecting the benchmark run to fabricate it.
+    """
+    monkeypatch.chdir(tmp_path)
+    data = np.linspace(0, 1, 200, dtype=np.float32).reshape(20, 10)
+    in_path = tmp_path / "data.zarr" / "raw"
+    prepare_ds(
+        in_path,
+        shape=data.shape,
+        voxel_size=Coordinate(1, 1),
+        dtype=data.dtype,
+        mode="w",
+    )[:] = data
+
+    def make(suffix="out", **kwargs):
+        kwargs.setdefault("out_array_dtype", np.dtype(np.uint8))
+        return LambdaTask(
+            in_data=Raw(store=in_path, writable=False),
+            out_data=Labels(store=tmp_path / "data.zarr" / suffix),
+            lambda_func=lambda x: (x > 0.5).astype(np.uint8),
+            block_size=Coordinate(10, 10),
+            **kwargs,
+        )
+
+    return make
+
+
+def traced_operations(trace_dir: Path = TRACE_DIR) -> list[tuple[str, str]]:
+    """The (task, operation) pairs recorded across every process's trace file."""
+    assert trace_dir.exists(), f"{trace_dir} was never created"
+    return [(record["task"], record["operation"]) for record in read_traces(trace_dir)]
+
+
+def test_benchmark_records_traces(tiny_task):
+    """benchmark() must actually record traces and write the report.
+
+    Regression test: every ``trace`` in volara goes through
+    ``BlockwiseTask.get_benchmark_logger``, which used to hard-code a ``None``
+    sink. The logger was therefore always inert and ``benchmark()`` recorded
+    nothing, no matter what ran.
+
+    pytest tests/test_benchmark.py::test_benchmark_records_traces
+    """
+    tiny_task().benchmark(multiprocessing=False)
+
+    traces = traced_operations()
+    assert len(traces) > 0, "benchmark() recorded no traces"
+
+    operations = {operation for _, operation in traces}
+    assert {"init", "Process Block", "Mark Block Done"} <= operations
+
+    # both blocks of the 20x10 volume should show up
+    assert sum(1 for _, op in traces if op == "Process Block") == 2
+
+    for name in ("time.csv", "memory.csv", "io.csv"):
+        report = Path("volara_benchmark_report") / name
+        assert report.exists(), f"{name} was not written"
+        assert "Process Block" in report.read_text()
+
+
+def test_benchmark_runs_the_task_for_real(tiny_task):
+    """The default benchmark path is an ordinary run, not a dry run.
+
+    Benchmarking a job as it runs normally for the first time is the common
+    case, so it is what ``benchmark()`` does with no arguments: the outputs and
+    the block done dataset are the real ones and they survive the run.
+
+    pytest tests/test_benchmark.py::test_benchmark_runs_the_task_for_real
+    """
+    task = tiny_task()
+    task.benchmark(multiprocessing=False)
+
+    assert task.out_data.store.exists(), "benchmark() produced no output data"
+    assert task.block_ds.exists(), "benchmark() left no block done dataset"
+    assert "volara_benchmark_logs" not in task.block_ds.parts, (
+        "benchmark() put the block done dataset under the benchmark log "
+        f"basedir instead of the ordinary one: {task.block_ds}"
+    )
+
+    written = task.out_data.array("r")[:]
+    assert written.sum() == 100, f"output was not written: {written.sum()}"
+
+    # every block is marked done, so an ordinary rerun has nothing left to do
+    blocks_done = open_ds(task.block_ds, mode="r")[:]
+    assert blocks_done.all(), f"blocks were left unmarked: {blocks_done}"
+
+
+def test_benchmark_spoof_leaves_no_artifacts(tiny_task):
+    """spoof=True still supports benchmarking a task that has already run.
+
+    pytest tests/test_benchmark.py::test_benchmark_spoof_leaves_no_artifacts
+    """
+    task = tiny_task()
+    task.benchmark(multiprocessing=False, spoof=True)
+
+    assert len(traced_operations()) > 0, "spoofed benchmark recorded no traces"
+    assert not task.out_data.store.exists(), "spoofed benchmark wrote real outputs"
+    assert not task.block_ds.exists(), "spoofed benchmark wrote a real block done ds"
+
+
+def test_pipeline_benchmark_records_traces(tiny_task):
+    """Pipeline.benchmark() records traces for every task in the pipeline.
+
+    pytest tests/test_benchmark.py::test_pipeline_benchmark_records_traces
+    """
+    pipeline = tiny_task("first") + tiny_task("second")
+    pipeline.benchmark(multiprocessing=False, out_dir=Path("report"))
+
+    tasks = {task for task, _ in traced_operations()}
+    assert len(tasks) == 2, f"expected both tasks to be traced, got {tasks}"
+    assert (Path("report") / "time.csv").exists()
+
+
+def test_benchmark_traces_the_worker_loop(tiny_task):
+    """The worker block loop is traced, not just the scheduling process.
+
+    pytest tests/test_benchmark.py::test_benchmark_traces_the_worker_loop
+    """
+    task = tiny_task(num_workers=1)
+    task.benchmark(multiprocessing=True)
+
+    traces = traced_operations()
+    # "Acquire Block" is only ever traced from inside the worker block loop
+    operations = {operation for _, operation in traces}
+    assert "Acquire Block" in operations, (
+        f"no worker-loop traces recorded, got {operations}"
+    )
+    # and the blocks really ran -- guard against a green assertion over a run
+    # where every block failed before doing any work
+    assert sum(1 for _, op in traces if op == "Process Block") == 2
+
+
+@pytest.mark.parametrize("spoof", [False, True])
+def test_benchmark_traces_a_worker_config_run(tiny_task, spoof):
+    """benchmark() + worker_config records rows, in both modes.
+
+    This is the distributed path, and the one that matters: workers are
+    separate interpreters started as ``volara-cli blockwise-worker``, so they
+    inherit nothing but the environment, and they have to resolve the same log
+    basedir as the scheduler. When they did not, every block died on
+    ``Expected a zarr Array at volara_logs/<task>-meta/blocks_done.zarr, got
+    Group`` while ``benchmark()`` still returned and still wrote a report --
+    which is why this asserts on ``Process Block``, not just on the run
+    completing.
+
+    pytest tests/test_benchmark.py::test_benchmark_traces_a_worker_config_run
+    """
+    # out_array_dtype is left unset: a np.dtype does not survive the
+    # model_dump_json that worker_config dispatch writes the config with
+    task = tiny_task(num_workers=1, worker_config=LocalWorker(), out_array_dtype=None)
+    task.benchmark(multiprocessing=True, spoof=spoof)
+
+    traces = traced_operations()
+    assert sum(1 for _, op in traces if op == "Process Block") == 2, (
+        f"blocks did not run in the worker; recorded {sorted(set(traces))}"
+    )
+    assert sum(1 for _, op in traces if op == "Mark Block Done") == 2
+
+
+def test_benchmarking_signal_reaches_child_processes(tmp_path):
+    """A freshly spawned interpreter inherits the "we are benchmarking" signal.
+
+    This is why the signal is an environment variable and not a module global:
+    ``worker_config`` dispatch starts workers as new interpreters
+    (``volara-cli blockwise-worker``), which would not see a global.
+
+    pytest tests/test_benchmark.py::test_benchmarking_signal_reaches_child_processes
+    """
+    probe = (
+        "from volara.blockwise.benchmark import get_benchmark_dir;"
+        "print(get_benchmark_dir())"
+    )
+
+    outside = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+    assert outside.stdout.strip() == "None"
+
+    trace_dir = tmp_path / "traces"
+    with benchmarking(trace_dir, tmp_path):
+        inside = subprocess.run(
+            [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+        )
+    assert inside.stdout.strip() == str(trace_dir)
+
+
+def test_run_blockwise_stays_unbenchmarked(tiny_task):
+    """Ordinary runs must not be traced -- that is the point of the guard.
+
+    pytest tests/test_benchmark.py::test_run_blockwise_stays_unbenchmarked
+    """
+    task = tiny_task()
+    assert get_benchmark_dir() is None
+    assert task.get_benchmark_logger().trace_dir is None
+
+    task.run_blockwise(multiprocessing=False)
+
+    assert not TRACE_DIR.exists(), "run_blockwise wrote benchmark traces"
+
+
+def test_benchmark_does_not_leak_the_signal(tiny_task, monkeypatch):
+    """benchmark() must leave the environment as it found it.
+
+    pytest tests/test_benchmark.py::test_benchmark_does_not_leak_the_signal
+    """
+    monkeypatch.delenv(BENCHMARK_DIR_ENV_VAR, raising=False)
+    tiny_task().benchmark(multiprocessing=False)
+
+    assert get_benchmark_dir() is None
+    assert tiny_task("after").get_benchmark_logger().trace_dir is None
+
+
+def test_report_of_an_empty_run_is_empty(tmp_path, capsys):
+    """A run that traced nothing prints an empty report instead of raising.
+
+    pytest tests/test_benchmark.py::test_report_of_an_empty_run_is_empty
+    """
+    empty = tmp_path / "traces"
+    empty.mkdir()
+    BenchmarkLogger(empty, task=None).print_report(tmp_path / "report")
+
+    assert "No benchmark data available." in capsys.readouterr().out
+    assert not (tmp_path / "report").exists()
+
+
+def _emit(trace_dir: Path, count: int):
+    logger = BenchmarkLogger(trace_dir, task="task-a")
+    for _ in range(count):
+        logger.log(worker_id=0, operation="Process Block", duration=1.0)
+
+
+def test_report_aggregates_across_concurrent_writers(tmp_path, capsys):
+    """The driver reduces every process's trace file into one report.
+
+    Concurrent writers are the case that used to lock the sqlite db. Here each
+    process owns a file of its own, so there is nothing to contend on and
+    nothing to lose.
+
+    pytest tests/test_benchmark.py::test_report_aggregates_across_concurrent_writers
+    """
+    trace_dir = tmp_path / "traces"
+    context = multiprocessing.get_context("spawn")
+    processes = [context.Process(target=_emit, args=(trace_dir, 50)) for _ in range(4)]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join()
+        assert process.exitcode == 0
+
+    assert len(read_traces(trace_dir)) == 4 * 50, "records were lost"
+    assert len(list(trace_dir.glob("*.jsonl"))) == 4, "processes shared a trace file"
+
+    BenchmarkLogger(trace_dir, task=None).print_report(tmp_path / "report")
+    assert (tmp_path / "report" / "time.csv").exists()
+    assert "1.0s ± 0.0" in capsys.readouterr().out

--- a/tests/test_lut.py
+++ b/tests/test_lut.py
@@ -1,6 +1,23 @@
+import fsspec
 import numpy as np
+import pytest
 
 from volara.lut import LUT, LUTS
+
+
+@pytest.fixture
+def fake_s3(monkeypatch):
+    """
+    Back `LUT._s3fs` with an in-memory fsspec filesystem so that s3 code
+    paths can be exercised without a bucket.
+    """
+    fs = fsspec.filesystem("memory")
+    fs.store.clear()
+    fs.pseudo_dirs.clear()
+    monkeypatch.setattr(LUT, "_s3fs", lambda self: fs)
+    yield fs
+    fs.store.clear()
+    fs.pseudo_dirs.clear()
 
 
 def test_lut_save_load(tmp_path):
@@ -54,6 +71,83 @@ def test_luts_load(tmp_path):
     loaded = luts.load()
     assert loaded.shape == (2, 4)
     np.testing.assert_array_equal(loaded, [[1, 2, 3, 4], [10, 20, 30, 40]])
+
+
+def test_lut_uri_local(tmp_path):
+    """`uri` is the normalized local path for non-s3 luts."""
+    lut = LUT(path=str(tmp_path / "local"))
+    assert not lut.is_s3
+    assert lut.uri == str(tmp_path / "local.npz")
+    assert lut.name == "local"
+
+
+def test_lut_s3_save_load(fake_s3):
+    lut = LUT(path="s3://bucket/path/to/data.zarr/lut.npz")
+    assert lut.is_s3
+    assert lut.uri == "s3://bucket/path/to/data.zarr/lut.npz"
+    assert lut.name == "lut"
+    assert not lut.exists()
+    assert lut.load() is None
+
+    data = np.array([[1, 2, 3], [10, 20, 30]])
+    lut.save(data)
+    assert lut.exists()
+    np.testing.assert_array_equal(lut.load(), data)
+
+
+def test_lut_s3_save_load_with_edges(fake_s3):
+    lut = LUT(path="s3://bucket/lut.npz")
+    data = np.array([[1, 2], [10, 20]])
+    edges = np.array([[1, 2, 0.5]])
+    lut.save(data, edges=edges)
+    np.testing.assert_array_equal(lut.load(), data)
+
+
+def test_lut_s3_extension_appended(fake_s3):
+    lut = LUT(path="s3://bucket/path/to/data.zarr/lut")
+    assert lut.uri == "s3://bucket/path/to/data.zarr/lut.npz"
+    lut.save(np.array([[1], [2]]))
+    assert fake_s3.exists("s3://bucket/path/to/data.zarr/lut.npz")
+
+
+def test_lut_s3_drop(fake_s3):
+    lut = LUT(path="s3://bucket/lut.npz")
+    lut.save(np.array([[1], [2]]))
+    assert lut.exists()
+    lut.drop()
+    assert not lut.exists()
+    # dropping a missing lut is a no-op
+    lut.drop()
+
+
+def test_lut_s3_file_raises(fake_s3):
+    """s3 luts have no local path."""
+    lut = LUT(path="s3://bucket/lut.npz")
+    with pytest.raises(ValueError, match="no local path"):
+        lut.file
+
+
+def test_luts_mixed_local_and_s3(tmp_path, fake_s3):
+    """Local and s3 luts can be combined."""
+    local = LUT(path=tmp_path / "a.npz")
+    remote = LUT(path="s3://bucket/b.npz")
+    local.save(np.array([[1, 2], [10, 20]]))
+    remote.save(np.array([[10, 20], [100, 200]]))
+
+    luts = local + remote
+    np.testing.assert_array_equal(luts.load(), [[1, 2, 10, 20], [10, 20, 100, 200]])
+    iterated = luts.load_iterated()
+    np.testing.assert_array_equal(iterated[0], [1, 2])
+    np.testing.assert_array_equal(iterated[1], [100, 200])
+
+
+def test_luts_load_skips_missing(tmp_path):
+    """Missing luts are skipped rather than breaking concatenation."""
+    lut_a = LUT(path=tmp_path / "a.npz")
+    lut_b = LUT(path=tmp_path / "missing.npz")
+    lut_a.save(np.array([[1, 2], [10, 20]]))
+    loaded = LUTS(luts=[lut_a, lut_b]).load()
+    np.testing.assert_array_equal(loaded, [[1, 2], [10, 20]])
 
 
 def test_luts_load_iterated(tmp_path):

--- a/volara/blockwise/benchmark.py
+++ b/volara/blockwise/benchmark.py
@@ -1,12 +1,134 @@
+import csv
+import json
 import os
-import sqlite3
+import statistics
 import time
+import uuid
 from collections import Counter, defaultdict, deque
 from contextlib import contextmanager
 from pathlib import Path
+from shutil import rmtree
 
 import daisy
 import psutil
+
+BENCHMARK_DIR_ENV_VAR = "VOLARA_BENCHMARK_DIR"
+"""
+Name of the environment variable that carries the directory a benchmark run
+writes its traces into. Its presence is also the "we are benchmarking" signal.
+
+An environment variable (rather than a module global) is what makes benchmarking
+work at all: block processing happens in worker processes -- forked
+(``num_cache_workers``) or freshly spawned (``worker_config`` -> ``volara-cli
+blockwise-worker``) -- and a module global would not survive the spawn. The
+environment is inherited by both.
+"""
+
+BENCHMARK_LOG_BASEDIR_ENV_VAR = "VOLARA_BENCHMARK_LOG_BASEDIR"
+"""
+Name of the environment variable carrying the ``volara.logging`` basedir that a
+benchmark run's workers must adopt.
+
+Workers otherwise take it from daisy's worker context, which is not reliable
+across daisy versions: daisy 2.0 dropped ``logdir`` from the worker context and
+falls back to the *worker's* own basedir, so a freshly spawned ``volara-cli
+blockwise-worker`` resolves ``volara_logs/<task>-meta`` while the scheduler
+created the block-done array somewhere else. Exporting it removes the guesswork.
+"""
+
+TRACE_SUFFIX = ".jsonl"
+
+_trace_file: Path | None = None
+_trace_pid: int | None = None
+
+
+def get_benchmark_dir() -> Path | None:
+    """
+    The directory this process should write benchmark traces into, or ``None``
+    when we are not inside a :meth:`BlockwiseTask.benchmark` /
+    :meth:`Pipeline.benchmark` run.
+
+    ``None`` is the normal case: it is what keeps ordinary ``run_blockwise``
+    executions untraced, so no production run pays for tracing.
+    """
+    benchmark_dir = os.environ.get(BENCHMARK_DIR_ENV_VAR)
+    return Path(benchmark_dir) if benchmark_dir else None
+
+
+def get_benchmark_log_basedir() -> Path | None:
+    """
+    The ``volara.logging`` basedir a benchmark run's workers must adopt, or
+    ``None`` outside a benchmark run.
+    """
+    log_basedir = os.environ.get(BENCHMARK_LOG_BASEDIR_ENV_VAR)
+    return Path(log_basedir) if log_basedir else None
+
+
+@contextmanager
+def benchmarking(benchmark_dir: Path | str, log_basedir: Path | str):
+    """
+    Mark this process (and any workers it starts) as benchmarking, so that
+    :meth:`BlockwiseTask.get_benchmark_logger` hands out live loggers writing
+    into ``benchmark_dir``, and so that workers log to ``log_basedir``.
+
+    Both paths are made absolute before being exported: workers do not
+    necessarily share the launching process's working directory.
+
+    Note: cluster backends that scrub the environment (e.g. ``bsub`` without
+    ``-env``) will not propagate these to remote workers; benchmarking those
+    tasks records only what the scheduling process itself traces.
+    """
+    exported = {
+        BENCHMARK_DIR_ENV_VAR: str(Path(benchmark_dir).absolute()),
+        BENCHMARK_LOG_BASEDIR_ENV_VAR: str(Path(log_basedir).absolute()),
+    }
+    previous = {key: os.environ.get(key) for key in exported}
+    os.environ.update(exported)
+    try:
+        yield Path(exported[BENCHMARK_DIR_ENV_VAR])
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+@contextmanager
+def benchmark_run(
+    benchmark_dir: Path | str = Path("volara_benchmark_logs"),
+    out_dir: Path | None = None,
+    relocate_logs: bool = False,
+):
+    """
+    Set a benchmark run up and tear it down: a fresh trace directory, the
+    signal exported to workers, and the report written on the way out however
+    the run ended.
+
+    Args:
+        relocate_logs: move the ``volara.logging`` basedir under
+            ``benchmark_dir`` for the duration. Only wanted for spoofed runs,
+            which must not touch the meta directories of the real task.
+    """
+    from volara.logging import get_log_basedir, set_log_basedir
+
+    benchmark_dir = Path(benchmark_dir)
+    trace_dir = benchmark_dir / "traces"
+    if trace_dir.exists():
+        rmtree(trace_dir)
+
+    previous_log_basedir = get_log_basedir()
+    log_basedir = benchmark_dir if relocate_logs else previous_log_basedir
+    set_log_basedir(log_basedir)
+    try:
+        with benchmarking(trace_dir, log_basedir):
+            benchmark_logger = BenchmarkLogger(trace_dir, task=None)
+            try:
+                yield benchmark_logger
+            finally:
+                benchmark_logger.print_report(out_dir)
+    finally:
+        set_log_basedir(previous_log_basedir)
 
 
 def partial_order(task_orders: dict[str, list[str]]) -> list[str]:
@@ -49,33 +171,75 @@ def partial_order(task_orders: dict[str, list[str]]) -> list[str]:
     return ops_list
 
 
-class BenchmarkLogger:
-    def __init__(self, db_path: Path | str | None, task: str | None):
-        db_path = Path(db_path) if db_path is not None else None
-        self.task = task
-        self.conn: None | sqlite3.Connection = None
-        if db_path is not None:
-            if not db_path.parent.exists():
-                db_path.parent.mkdir(parents=True, exist_ok=True)
-            self.conn = sqlite3.connect(db_path, timeout=30, check_same_thread=False)
-        else:
-            self.conn = None
+def _process_trace_file(trace_dir: Path) -> Path:
+    """
+    The trace file this process appends to, created on first use.
 
-    def _init_db(self):
-        if self.conn is not None:
-            # Table with flexible key:value columns
-            self.conn.execute("""
-                CREATE TABLE IF NOT EXISTS benchmark (
-                    task TEXT,
-                    worker_id INT,
-                    operation TEXT,
-                    duration REAL,
-                    cpu_usage REAL,
-                    mem_usage REAL,
-                    io_read INT,
-                    io_write INT
-                )
-            """)
+    One file per process is the whole concurrency story: nothing is shared
+    between writers, so there is no lock to contend on. The pid is part of the
+    cache key because a forked worker inherits this module's globals and must
+    not keep writing to its parent's file.
+    """
+    global _trace_file, _trace_pid
+
+    pid = os.getpid()
+    if _trace_file is None or _trace_pid != pid or _trace_file.parent != trace_dir:
+        trace_dir.mkdir(parents=True, exist_ok=True)
+        _trace_file = trace_dir / f"{pid}-{uuid.uuid4().hex[:8]}{TRACE_SUFFIX}"
+        _trace_pid = pid
+    return _trace_file
+
+
+def read_traces(trace_dir: Path) -> list[dict]:
+    """
+    Every trace record written under ``trace_dir``, across all processes.
+
+    A record that does not parse is skipped rather than raising: a worker killed
+    mid-write can leave a truncated final line, and a partial report is more
+    useful than a crash in a ``finally`` block.
+    """
+    records = []
+    for trace_file in sorted(trace_dir.glob(f"*{TRACE_SUFFIX}")):
+        with open(trace_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    return records
+
+
+def current_worker_id() -> int:
+    """
+    The daisy worker id of this process, or ``-1`` outside a worker.
+
+    Read straight out of the environment: ``daisy.Client()`` opens a TCP
+    connection to the scheduler, which is far too expensive to do once per
+    traced operation.
+    """
+    if daisy.Context.ENV_VARIABLE not in os.environ:
+        return -1
+    try:
+        return int(daisy.Context.from_env()["worker_id"])
+    except (KeyError, ValueError):
+        return -1
+
+
+class BenchmarkLogger:
+    """
+    Appends one JSON record per traced operation to this process's own trace
+    file under ``trace_dir``, and reduces all of them into a report.
+
+    ``trace_dir=None`` makes the logger inert -- every ``log``/``trace`` becomes
+    a no-op. That is the normal state outside a benchmark run.
+    """
+
+    def __init__(self, trace_dir: Path | str | None, task: str | None):
+        self.trace_dir = Path(trace_dir) if trace_dir is not None else None
+        self.task = task
 
     def log(
         self,
@@ -87,29 +251,27 @@ class BenchmarkLogger:
         io_read: int = 0,
         io_write: int = 0,
     ):
-        if self.conn is not None:
-            self.conn.execute(
-                "INSERT INTO benchmark VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    self.task,
-                    worker_id,
-                    operation,
-                    duration,
-                    cpu_usage,
-                    mem_usage,
-                    io_read,
-                    io_write,
-                ),
-            )
-            self.conn.commit()
+        if self.trace_dir is None:
+            return
+        record = {
+            "task": self.task,
+            "worker_id": worker_id,
+            "operation": operation,
+            "duration": duration,
+            "cpu_usage": cpu_usage,
+            "mem_usage": mem_usage,
+            "io_read": io_read,
+            "io_write": io_write,
+        }
+        # One append-mode write of one line: POSIX makes that atomic with
+        # respect to the file offset, so a fork that raced ahead of
+        # `_process_trace_file` still cannot interleave two records.
+        with open(_process_trace_file(self.trace_dir), "a") as f:
+            f.write(json.dumps(record) + "\n")
 
     @contextmanager
     def trace(self, operation: str):
-        if self.conn is not None:
-            if daisy.Context.ENV_VARIABLE in os.environ:
-                worker_id = daisy.Client().worker_id
-            else:
-                worker_id = -1
+        if self.trace_dir is not None:
             proc = psutil.Process(os.getpid())
             if hasattr(proc, "io_counters"):
                 io_before = proc.io_counters()
@@ -136,7 +298,7 @@ class BenchmarkLogger:
                 cpu_usage = cpu_after.user - cpu_before.user
                 mem_usage = mem_after.rss - mem_before.rss
                 self.log(
-                    worker_id,
+                    current_worker_id(),
                     operation,
                     end - start,
                     cpu_usage,
@@ -148,111 +310,78 @@ class BenchmarkLogger:
             yield
 
     def print_report(self, out_dir: Path | None = None):
-        import polars as pl
-
+        """
+        Reduce every process's traces into a time/memory/io report, print the
+        timing table, and write all three as csv under ``out_dir``.
+        """
         if out_dir is None:
             out_dir = Path("./volara_benchmark_report")
-        if self.conn is not None:
-            cursor = self.conn.cursor()
-            cursor.execute("SELECT * FROM benchmark;")
-            rows = list(cursor.fetchall())
-            cursor.close()
 
-            # Extract orderings from `rows`
-            task_orders = {}
-            seen = set()
-
-            for row in rows:
-                task, _, op, *_ = row
-                if (task, op) not in seen:
-                    task_orders.setdefault(task, []).append(op)
-                    seen.add((task, op))
-
-            ops_order = partial_order(task_orders)
-            task_order = list(task_orders.keys())
-
-            # Convert to Polars DataFrame
-            df = pl.DataFrame(
-                rows,
-                schema=[
-                    "task",
-                    "worker_id",
-                    "operation",
-                    "duration",
-                    "cpu_usage",
-                    "mem_usage",
-                    "io_read",
-                    "io_write",
-                ],
-            )
-            task_rank = {task: i for i, task in enumerate(task_order)}
-
-            # Group by task and operation, compute mean and std
-            agg_df = (
-                df.group_by(["task", "operation"])
-                .agg(
-                    [
-                        pl.col("duration").mean().alias("wall_mean"),
-                        pl.col("duration").std().alias("wall_std"),
-                        pl.col("cpu_usage").mean().alias("cpu_mean"),
-                        pl.col("mem_usage").max().alias("max_mem"),
-                        pl.col("io_read").mean().alias("read_mean"),
-                        pl.col("io_write").mean().alias("write_mean"),
-                    ]
-                )
-                .with_columns(
-                    pl.col("task")
-                    .map_elements(lambda x: task_rank.get(x, float("inf")))
-                    .alias("_rank")
-                )
-                .sort(by="_rank")
-                .drop("_rank")
-            )
-
-            # Combine mean ± std into a formatted string
-            time_df = agg_df.with_columns(
-                [
-                    pl.format(
-                        "{}s ± {} (idle: {}s)",
-                        pl.col("wall_mean").round(3),
-                        pl.col("wall_std").fill_null(0).round(3),
-                        (
-                            pl.col("wall_mean").round(3) - pl.col("cpu_mean").round(3)
-                        ).round(3),
-                    ).alias("time_profile")
-                ]
-            )
-            mem_df = agg_df.with_columns(
-                [
-                    pl.format(
-                        "{} MB",
-                        (pl.col("max_mem") / (1024 * 1024)).round(2),
-                    ).alias("mem_profile")
-                ]
-            )
-            io_df = agg_df.with_columns(
-                [
-                    pl.format(
-                        "read/write: {}/{} MB",
-                        (pl.col("read_mean") / (1024 * 1024)).round(2),
-                        (pl.col("write_mean") / (1024 * 1024)).round(2),
-                    ).alias("io_profile")
-                ]
-            )
-
-            # Pivot to wide table: rows = task, columns = operation, values = duration_str
-            time_df = (
-                time_df.pivot(on="operation", index="task", values="time_profile")
-            ).select(["task"] + ops_order)
-            mem_df = mem_df.pivot(
-                on="operation", index="task", values="mem_profile"
-            ).select(["task"] + ops_order)
-            io_df = io_df.pivot(
-                on="operation", index="task", values="io_profile"
-            ).select(["task"] + ops_order)
-
-            time_df.write_csv(out_dir / "time.csv")
-            mem_df.write_csv(out_dir / "memory.csv")
-            io_df.write_csv(out_dir / "io.csv")
-        else:
+        records = (
+            read_traces(self.trace_dir)
+            if self.trace_dir is not None and self.trace_dir.exists()
+            else []
+        )
+        if len(records) == 0:
             print("No benchmark data available.")
+            return
+
+        # Operation order comes from the order operations were first seen within
+        # each task, reconciled across tasks into a single partial order.
+        task_orders: dict[str, list[str]] = {}
+        seen = set()
+        for record in records:
+            key = (record["task"], record["operation"])
+            if key not in seen:
+                task_orders.setdefault(record["task"], []).append(record["operation"])
+                seen.add(key)
+        ops_order = partial_order(task_orders)
+        task_order = list(task_orders.keys())
+
+        grouped: dict[tuple[str, str], list[dict]] = defaultdict(list)
+        for record in records:
+            grouped[(record["task"], record["operation"])].append(record)
+
+        time_profiles: dict[tuple[str, str], str] = {}
+        mem_profiles: dict[tuple[str, str], str] = {}
+        io_profiles: dict[tuple[str, str], str] = {}
+        for key, group in grouped.items():
+            durations = [record["duration"] for record in group]
+            wall_mean = round(statistics.fmean(durations), 3)
+            wall_std = round(statistics.stdev(durations), 3) if len(group) > 1 else 0.0
+            cpu_mean = round(statistics.fmean(r["cpu_usage"] for r in group), 3)
+            max_mem = max(record["mem_usage"] for record in group)
+            read_mean = statistics.fmean(record["io_read"] for record in group)
+            write_mean = statistics.fmean(record["io_write"] for record in group)
+
+            time_profiles[key] = (
+                f"{wall_mean}s ± {wall_std} (idle: {round(wall_mean - cpu_mean, 3)}s)"
+            )
+            mem_profiles[key] = f"{round(max_mem / (1024 * 1024), 2)} MB"
+            io_profiles[key] = (
+                f"read/write: {round(read_mean / (1024 * 1024), 2)}/"
+                f"{round(write_mean / (1024 * 1024), 2)} MB"
+            )
+
+        header = ["task"] + ops_order
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for name, profiles in (
+            ("time.csv", time_profiles),
+            ("memory.csv", mem_profiles),
+            ("io.csv", io_profiles),
+        ):
+            rows = [
+                [task] + [profiles.get((task, op), "") for op in ops_order]
+                for task in task_order
+            ]
+            with open(out_dir / name, "w", newline="") as f:
+                csv.writer(f).writerows([header] + rows)
+            if name == "time.csv":
+                print_table([header] + rows)
+        print(f"Benchmark report written to {out_dir}")
+
+
+def print_table(rows: list[list[str]]):
+    widths = [max(len(row[i]) for row in rows) for i in range(len(rows[0]))]
+    for row in rows:
+        print("  ".join(cell.ljust(width) for cell, width in zip(row, widths)))

--- a/volara/blockwise/benchmark.py
+++ b/volara/blockwise/benchmark.py
@@ -116,6 +116,9 @@ def benchmark_run(
     trace_dir = benchmark_dir / "traces"
     if trace_dir.exists():
         rmtree(trace_dir)
+    # The cached handle in _process_trace_file points into the directory just removed. A second
+    # benchmark() in one interpreter would hit that cache, skip the mkdir, and fail to append.
+    _reset_trace_file()
 
     previous_log_basedir = get_log_basedir()
     log_basedir = benchmark_dir if relocate_logs else previous_log_basedir
@@ -184,10 +187,19 @@ def _process_trace_file(trace_dir: Path) -> Path:
 
     pid = os.getpid()
     if _trace_file is None or _trace_pid != pid or _trace_file.parent != trace_dir:
-        trace_dir.mkdir(parents=True, exist_ok=True)
         _trace_file = trace_dir / f"{pid}-{uuid.uuid4().hex[:8]}{TRACE_SUFFIX}"
         _trace_pid = pid
+    # Unconditional: the directory can be removed under a live cache entry (benchmark_run wipes it
+    # at the start of every run), and a cache hit must still hand back a writable path.
+    trace_dir.mkdir(parents=True, exist_ok=True)
     return _trace_file
+
+
+def _reset_trace_file() -> None:
+    """Forget this process's cached trace file, so the next write mints a fresh one."""
+    global _trace_file, _trace_pid
+    _trace_file = None
+    _trace_pid = None
 
 
 def read_traces(trace_dir: Path) -> list[dict]:

--- a/volara/blockwise/blockwise.py
+++ b/volara/blockwise/blockwise.py
@@ -19,7 +19,12 @@ from volara.logging import get_log_basedir, set_log_basedir
 
 from ..utils import PydanticRoi, StrictBaseModel
 from ..workers import Worker
-from .benchmark import BenchmarkLogger
+from .benchmark import (
+    BenchmarkLogger,
+    benchmark_run,
+    get_benchmark_dir,
+    get_benchmark_log_basedir,
+)
 
 if TYPE_CHECKING:
     from .pipeline import Pipeline
@@ -257,6 +262,14 @@ class BlockwiseTask(StrictBaseModel, ABC):
         Start our workers and run through every block until a task
         is complete.
         """
+        benchmark_log_basedir = get_benchmark_log_basedir()
+        if benchmark_log_basedir is not None:
+            # A benchmark run may relocate the log basedir, and with it this
+            # task's meta dir and block-done array. Adopt it before anything
+            # resolves a path off it -- daisy's worker context cannot be relied
+            # on to carry it (see BENCHMARK_LOG_BASEDIR_ENV_VAR).
+            set_log_basedir(benchmark_log_basedir)
+
         benchmark_logger = self.get_benchmark_logger()
         with ExitStack() as stack:
             with benchmark_logger.trace("Process Block Setup"):
@@ -265,11 +278,13 @@ class BlockwiseTask(StrictBaseModel, ABC):
             def worker_loop():
                 worker_benchmark_logger = self.get_benchmark_logger()
                 client = daisy.Client()
-                # TODO: this shouldn't be necessary, daisy should be doing this for us
-                try:
-                    set_log_basedir(client.context["logdir"])  # type: ignore[non-subscriptable]
-                except KeyError as e:
-                    raise ValueError(client.context) from e
+                if benchmark_log_basedir is None:
+                    # TODO: this shouldn't be necessary, daisy should be doing
+                    # this for us
+                    try:
+                        set_log_basedir(client.context["logdir"])  # type: ignore[non-subscriptable]
+                    except KeyError as e:
+                        raise ValueError(client.context) from e
                 mark_block_done = self.mark_block_done_func()
 
                 while True:
@@ -408,9 +423,17 @@ class BlockwiseTask(StrictBaseModel, ABC):
             yield task
 
     def get_benchmark_logger(self) -> BenchmarkLogger:
-        _benchmark_db_path = Path("volara_benchmark_logs/benchmark.db")
+        """
+        The logger every ``trace``/``log`` call in this codebase goes through.
+
+        Returns a live logger only while a :meth:`benchmark` run is in progress
+        (signalled by ``VOLARA_BENCHMARK_DIR``, which ``benchmarking()`` exports
+        so that worker processes see it too). Outside of a benchmark run
+        ``get_benchmark_dir()`` is ``None`` and every ``trace``/``log`` becomes a
+        no-op -- ordinary ``run_blockwise`` executions stay untraced.
+        """
         return BenchmarkLogger(
-            None,
+            get_benchmark_dir(),
             task=self.task_name,
         )
 
@@ -428,48 +451,48 @@ class BlockwiseTask(StrictBaseModel, ABC):
                 data[name] = value
         return self.__class__(**data)
 
-    def benchmark(self, multiprocessing: bool = True) -> dict:
+    def benchmark(
+        self,
+        multiprocessing: bool = True,
+        spoof: bool = False,
+        out_dir: Path | None = None,
+    ) -> dict:
         """
-        A helper function for benchmarking and debugging a blockwise task or pipeline.
+        Run this task with tracing switched on and write a timing, memory and
+        io report.
 
-        Used as a "dry run" of `run_blockwise` without saving any outputs.
+        By default this is an ordinary :meth:`run_blockwise` with tracing added:
+        real outputs, real block done dataset, already-completed blocks still
+        skipped. That is the common case -- benchmarking a job as it runs
+        normally, the first time.
 
-        - Will not skip blocks that have already been processed. You can benchmark a task
-            that has already been run.
-        - Will not save any run artifacts such as block done datasets, output datasets,
-            graph nodes or edges, or look up tables. The only thing that will be saved are the
-            worker logs and a timing report.
+        Args:
+            spoof: run against spoofed outputs instead, dropping every artifact
+                afterwards, so that a task which has already run (or is running)
+                can be benchmarked without disturbing the data it produced. No
+                block is skipped in this mode: the spoofed task has its own,
+                empty, block done dataset.
+            out_dir: where to write the report. Defaults to
+                ``./volara_benchmark_report``.
         """
-        from volara.logging import set_log_basedir
+        with benchmark_run(out_dir=out_dir, relocate_logs=spoof):
+            run_self = (
+                self.spoof(Path("volara_benchmark_logs/spoof")) if spoof else self
+            )
 
-        log_basedir = get_log_basedir()
-        set_log_basedir("volara_benchmark_logs")
-        benchmark_db_path = Path("volara_benchmark_logs/benchmark.db")
-        if benchmark_db_path.exists():
-            benchmark_db_path.unlink()
-        benchmark_logger = BenchmarkLogger(task=None, db_path=benchmark_db_path)
-        benchmark_logger._init_db()
+            try:
+                with run_self.task(multiprocessing=multiprocessing) as task:
+                    tasks = [task]
+                    if multiprocessing:
+                        result = daisy.run_blockwise(tasks)  # noqa
+                    else:
+                        server = daisy.SerialServer()
+                        _cl_monitor = CLMonitor(server)
+                        result = server.run_blockwise(tasks)
 
-        spoof_dir = Path("volara_benchmark_logs/spoof")
-        debug_self = self.spoof(spoof_dir)
-
-        try:
-            with debug_self.task(multiprocessing=multiprocessing) as task:
-                tasks = [task]
-                if multiprocessing:
-                    result = daisy.run_blockwise(tasks)  # noqa
-                else:
-                    server = daisy.SerialServer()
-                    _cl_monitor = CLMonitor(server)
-                    result = server.run_blockwise(tasks)
-
-        except Exception as e:
-            raise e
-
-        finally:
-            debug_self.drop()
-            benchmark_logger.print_report()
-            set_log_basedir(log_basedir)
+            finally:
+                if spoof:
+                    run_self.drop()
 
         return result
 

--- a/volara/blockwise/blockwise.py
+++ b/volara/blockwise/blockwise.py
@@ -268,6 +268,11 @@ class BlockwiseTask(StrictBaseModel, ABC):
             # task's meta dir and block-done array. Adopt it before anything
             # resolves a path off it -- daisy's worker context cannot be relied
             # on to carry it (see BENCHMARK_LOG_BASEDIR_ENV_VAR).
+            # This is early enough because it runs at the entry point of the only
+            # process that needs it: a freshly spawned worker (volara-cli
+            # blockwise-worker -> process_blocks), which never runs task()/init.
+            # init traces driver-side, where benchmark_run() has already set the
+            # basedir (and exported both env vars) before task() is entered.
             set_log_basedir(benchmark_log_basedir)
 
         benchmark_logger = self.get_benchmark_logger()

--- a/volara/blockwise/pipeline.py
+++ b/volara/blockwise/pipeline.py
@@ -8,7 +8,7 @@ import daisy
 import networkx as nx
 from daisy.cl_monitor import CLMonitor
 
-from .benchmark import BenchmarkLogger
+from .benchmark import benchmark_run
 
 if TYPE_CHECKING:
     from .blockwise import BlockwiseTask
@@ -82,59 +82,61 @@ class Pipeline:
 
         return combined_pipeline
 
-    def benchmark(self, multiprocessing: bool = True, out_dir: Path | None = None):
+    def benchmark(
+        self,
+        multiprocessing: bool = True,
+        spoof: bool = False,
+        out_dir: Path | None = None,
+    ):
         """
-        Run the pipeline in a benchmark mode, which will run each task
-        in the pipeline and log the time taken for each task.
+        Run the pipeline with tracing switched on and write a timing, memory and
+        io report covering every task in it.
+
+        By default this is an ordinary :meth:`run_blockwise` with tracing added.
+        See :meth:`BlockwiseTask.benchmark` for ``spoof`` and ``out_dir``.
         """
-        from volara.logging import get_log_basedir, set_log_basedir
+        with benchmark_run(out_dir=out_dir, relocate_logs=spoof):
+            run_graph = (
+                nx.relabel_nodes(
+                    self.task_graph,
+                    lambda x: x.spoof(Path("volara_benchmark_logs/spoof")),
+                )
+                if spoof
+                else self.task_graph
+            )
+            node_ordering = list(nx.topological_sort(run_graph))
 
-        log_basedir = get_log_basedir()
-        set_log_basedir("volara_benchmark_logs")
-        benchmark_db_path = Path("volara_benchmark_logs/benchmark.db")
-        if benchmark_db_path.exists():
-            benchmark_db_path.unlink()
-        benchmark_logger = BenchmarkLogger(task=None, db_path=benchmark_db_path)
-        benchmark_logger._init_db()
+            try:
+                with ExitStack() as stack:
+                    task_map: dict[BlockwiseTask, daisy.Task] = {}
+                    for node in node_ordering:
+                        upstream_tasks = [
+                            task_map[upstream]
+                            for upstream in run_graph.predecessors(node)
+                        ]
+                        task = node.task(
+                            upstream_tasks=upstream_tasks,
+                            multiprocessing=multiprocessing,
+                        )
+                        task = stack.enter_context(task)
+                        task_map[node] = task
 
-        tmp_path = Path("volara_benchmark_logs/spoof")
-        spoof_graph = nx.relabel_nodes(
-            self.task_graph,
-            lambda x: x.spoof(tmp_path),
-        )
-        node_ordering = list(nx.topological_sort(spoof_graph))
+                    all_tasks = list(task_map.values())
 
-        try:
-            with ExitStack() as stack:
-                task_map: dict[BlockwiseTask, daisy.Task] = {}
-                for node in node_ordering:
-                    upstream_tasks = [
-                        task_map[upstream]
-                        for upstream in spoof_graph.predecessors(node)
-                    ]
-                    task = node.task(
-                        upstream_tasks=upstream_tasks, multiprocessing=multiprocessing
-                    )
-                    task = stack.enter_context(task)
-                    task_map[node] = task
+                    if multiprocessing:
+                        daisy.run_blockwise(all_tasks)
+                    else:
+                        server = daisy.SerialServer()
+                        _cl_monitor = CLMonitor(server)
+                        server.run_blockwise(all_tasks)
 
-                all_tasks = list(task_map.values())
+            except Exception as e:
+                logger.exception(e)
 
-                if multiprocessing:
-                    daisy.run_blockwise(all_tasks)
-                else:
-                    server = daisy.SerialServer()
-                    _cl_monitor = CLMonitor(server)
-                    server.run_blockwise(all_tasks)
-
-        except Exception as e:
-            logger.exception(e)
-
-        finally:
-            for node in node_ordering:
-                node.drop()
-            benchmark_logger.print_report(out_dir)
-            set_log_basedir(log_basedir)
+            finally:
+                if spoof:
+                    for node in node_ordering:
+                        node.drop()
 
     def run_blockwise(self, multiprocessing: bool = True):
         with ExitStack() as stack:

--- a/volara/lut.py
+++ b/volara/lut.py
@@ -1,5 +1,6 @@
+import io
 from collections.abc import Sequence
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import numpy as np
 
@@ -15,16 +16,59 @@ class LUT(StrictBaseModel):
 
     path: Path | str
     """
-    The path at which we will read/write the look up table
+    The path at which we will read/write the look up table. Either a local
+    path (`/path/to/data.zarr/lut.npz`) or an s3 uri
+    (`s3://bucket/path/to/data.zarr/lut.npz`). The `.npz` extension will be
+    appended if it is missing from a string path.
+    """
+
+    s3_kwargs: dict | None = None
+    """
+    Optional config for S3-compatible stores like Lyve Cloud.
+    Leave as None for standard S3 behavior (credentials from the environment).
+    Only used when `path` is an `s3://` uri.
     """
 
     @property
+    def is_s3(self) -> bool:
+        """
+        Whether this look up table lives in an s3 bucket rather than on
+        the local filesystem.
+        """
+        return isinstance(self.path, str) and self.path.startswith("s3://")
+
+    def _s3fs(self):
+        import s3fs  # type: ignore[unresolved-import]
+
+        if self.s3_kwargs is None:
+            return s3fs.S3FileSystem()
+
+        return s3fs.S3FileSystem(**self.s3_kwargs)
+
+    @property
+    def uri(self) -> str:
+        """
+        The normalized location of this look up table as a string. This is
+        the only accessor that works for both local and s3 look up tables.
+        """
+        if self.is_s3:
+            path = str(self.path)
+            return path if path.endswith(".npz") else f"{path}.npz"
+        return str(self.file)
+
+    @property
     def name(self) -> str:
+        if self.is_s3:
+            return PurePosixPath(self.uri).stem
         return self.file.stem
 
     @property
     def file(self) -> Path:
         if isinstance(self.path, str):
+            if self.is_s3:
+                raise ValueError(
+                    f"{self.path} is an s3 uri and has no local path, use `uri` instead"
+                )
             return (
                 Path(self.path)
                 if self.path.endswith(".npz")
@@ -35,27 +79,55 @@ class LUT(StrictBaseModel):
         else:
             raise TypeError(f"Invalid type for path ({self.path}): {type(self.path)}")
 
+    def exists(self) -> bool:
+        if self.is_s3:
+            return self._s3fs().exists(self.uri)
+        return self.file.exists()
+
     def drop(self):
-        if self.file.exists():
+        if self.is_s3:
+            fs = self._s3fs()
+            try:
+                fs.rm(self.uri)
+            except FileNotFoundError:
+                pass
+            fs.invalidate_cache(self.uri)
+        elif self.file.exists():
             self.file.unlink()
 
     def save(self, lut: np.ndarray, edges=None):
+        arrays = {"fragment_segment_lut": lut.astype(int)}
         if edges is not None:
-            np.savez_compressed(
-                self.file, fragment_segment_lut=lut.astype(int), edges=edges
-            )
+            arrays["edges"] = edges
+
+        if self.is_s3:
+            fs = self._s3fs()
+            with fs.open(self.uri, "wb") as f:
+                np.savez_compressed(f, **arrays)
+            fs.invalidate_cache(self.uri)
         else:
-            np.savez_compressed(self.file, fragment_segment_lut=lut.astype(int))
+            np.savez_compressed(self.file, **arrays)
 
     def load(self) -> np.ndarray | None:
+        if self.is_s3:
+            fs = self._s3fs()
+            if not fs.exists(self.uri):
+                return None
+            with fs.open(self.uri, "rb") as f:
+                buffer = io.BytesIO(f.read())
+            with np.load(buffer) as data:
+                return data["fragment_segment_lut"]
+
         if not self.file.exists():
             return None
-        return np.load(self.file)["fragment_segment_lut"]
+        with np.load(self.file) as data:
+            return data["fragment_segment_lut"]
 
     def __add__(self, other):
         """
-        Add two disjoint LUTs together via simple concatenation.
-        i.e. {0:1} + {1:2} = {0:2}
+        Add two disjoint LUTs together. See `LUTS.load` for concatenation of
+        disjoint mappings i.e. {0:1} + {2:3} = {0:1, 2:3}, and
+        `LUTS.load_iterated` for chaining mappings i.e. {0:1} + {1:2} = {0:2}.
         """
         if isinstance(other, LUT):
             return LUTS(luts=[self, other])
@@ -68,14 +140,15 @@ class LUTS:
 
     def __add__(self, other):
         if isinstance(other, LUTS):
-            return LUTS(self.luts + other.luts)
+            return LUTS(list(self.luts) + list(other.luts))
         elif isinstance(other, LUT):
             return LUTS(list(self.luts) + [other])
         raise TypeError(f"Cannot add {type(other)} to LUTS")
 
     def load(self):
+        mappings = (lut.load() for lut in self.luts)
         return np.concatenate(
-            [lut.load() for lut in self.luts if lut.load() is not None], axis=1
+            [mapping for mapping in mappings if mapping is not None], axis=1
         )  # type: ignore
 
     def load_iterated(self):


### PR DESCRIPTION
## What this is

An overhaul of volara's benchmarking, replacing the patch this PR used to be.
@pattonw's [review](https://github.com/e11bio/volara/pull/56#issuecomment-5185545231)
called the previous version "patching over some poor design decisions in the
original benchmarking implementation" and raised three points; this answers all
three, and fixes the bug the patch was originally for.

## The bug underneath

`BlockwiseTask.get_benchmark_logger` is the **only** way any code in volara gets
a `BenchmarkLogger` — every `trace()` in `blockwise.py`, `extract_frags.py`,
`aff_agglom.py`, `graph_mws.py` and `relabel.py` goes through it. On `main` it
reads:

```python
def get_benchmark_logger(self) -> BenchmarkLogger:
    _benchmark_db_path = Path("volara_benchmark_logs/benchmark.db")   # computed...
    return BenchmarkLogger(
        None,                                                        # ...and discarded
        task=self.task_name,
    )
```

With `db_path=None` the logger's connection is `None` and both `log()` and
`trace()` early-return, so no writer in the codebase ever wrote a row.
`benchmark()` then called `print_report()` on a table nobody had written to,
which raised out of a `finally` block.

## What changed

| | `main` | this branch |
|---|---|---|
| what `benchmark()` runs | always a spoofed dry run | a **real run**, traced. `spoof=True` for the dry run |
| trace sink | one sqlite db, every worker writing to it | one append-only `.jsonl` per process, reduced in the driver |
| report | polars | `statistics` + `csv` — `polars` removed from `pyproject.toml` |
| per-trace cost | a fresh `daisy.Client()`, i.e. a TCP connect to the scheduler | an `os.environ` read |
| `benchmark()` + `worker_config` | broken under daisy 2.0 (below) | works; pinned by a test **under daisy 1.2.2 only** — `pyproject.toml` pins `daisy>=1.2.2,<2`, so CI cannot reach the 2.0.0 path where the log-basedir regression lives; that half was verified by hand, not by CI |
| empty report | `InvalidOperationError` out of a `finally` | prints an empty report |

**(a) the common case.** Benchmarking a job as it runs normally, the first time,
is what `benchmark()` now does with no arguments: real outputs, real block done
dataset, already-done blocks still skipped, ordinary log basedir. Spoofing
outputs so that an already-run or mid-run task can be benchmarked without
disturbing its data is still there as `benchmark(spoof=True)` — including
dropping every artifact afterwards. Same for `Pipeline.benchmark`.

**(b) sqlite.** Gone. Each process appends to a trace file of its own under
`volara_benchmark_logs/traces/`, one JSON record per traced operation; the
driver globs and reduces them at the end. Nothing is shared between writers, so
there is no lock to contend on — the same "one writer per key" property as the
block done zarr. Files rather than a zarr because a trace is not one-per-block:
there is `init` per task, and nested per-block operations (`Read Affs`,
`Compute Fragments`, `Write Fragments`, …), so there is no block-indexed array
to write into without inventing an operation axis.

**(c) polars.** Gone from the benchmark path *and* from `pyproject.toml` —
`print_report` was its only user anywhere in volara. Aggregation is
`statistics.fmean`/`stdev`, output is `csv.writer`, and the formatting is
unchanged. Worth noting the zombie-process symptom is at least partly retired
already: `test_benchmark_traces_the_worker_loop` runs `multiprocessing=True` and
passed on all six test legs before this change too.

### `benchmark()` + `worker_config`, and a correction

My earlier note on this PR said this path fails. Correcting that: on **daisy
1.2.2** — what `pyproject.toml` resolves and what CI runs — I could not
reproduce it; 2/2 blocks complete and rows land. It reproduces on **daisy
2.0.0**, where `Client.__init__` no longer puts `logdir` in the worker context
and falls back to the *worker's* own log basedir. A freshly spawned `volara-cli
blockwise-worker` therefore resolved `volara_logs/<task>-meta/blocks_done.zarr`
while the scheduler had created it under the benchmark basedir:

```
TypeError: Expected a zarr Array at volara_logs/spoof_out-lambda-meta/blocks_done.zarr, got Group
```

— every block failed while `benchmark()` still returned and still wrote a
report. A benchmark run now exports its log basedir and workers adopt it
directly, which is right under both versions.
`test_benchmark_traces_a_worker_config_run` pins it, and asserts on the
`Process Block` count rather than on the run completing, precisely because
completing is not evidence.

## Reproduction

Same script both sides. It uses `worker_config=LocalWorker()`, i.e. the
distributed path, since that is the one that has to work.

```python
# bench_repro.py -- usage: python bench_repro.py <workdir>
import os
import sys
from pathlib import Path

import numpy as np
from funlib.geometry import Coordinate
from funlib.persistence.arrays import prepare_ds

from volara.blockwise import LambdaTask
from volara.datasets import Labels, Raw
from volara.workers import LocalWorker

work = Path(sys.argv[1]).absolute()
work.mkdir(parents=True, exist_ok=True)
os.chdir(work)
data = np.linspace(0, 1, 200, dtype=np.float32).reshape(20, 10)
raw = work / "data.zarr" / "raw"
prepare_ds(raw, shape=data.shape, voxel_size=Coordinate(1, 1),
           dtype=data.dtype, mode="w")[:] = data

task = LambdaTask(
    in_data=Raw(store=raw, writable=False),
    out_data=Labels(store=work / "data.zarr" / "out"),
    lambda_func=lambda x: (x > 0.5).astype(np.uint8),
    block_size=Coordinate(10, 10),   # -> 2 blocks
    num_workers=2,
    worker_config=LocalWorker(),     # the distributed path
)

try:
    task.benchmark(multiprocessing=True)
    print("benchmark() returned cleanly")
except Exception as e:
    print(f"benchmark() raised {type(e).__name__}: {str(e).splitlines()[0]}")

print("output written by the run:", (work / "data.zarr" / "out").exists())
for csv in sorted(Path("volara_benchmark_report").glob("*.csv")):
    print(f"--- {csv.name} ---")
    print(csv.read_text(), end="")
```

**On `main` (66106bb), daisy 1.2.2:**

```
Symlinking .../data.zarr/raw
Spoofing .../data.zarr/out

Execution Summary
-----------------

  Task spoof_out-lambda:

    num blocks : 2
    completed ✔: 2 (skipped 0)
    failed    ✗: 0
    orphaned  ∅: 0

    all blocks processed successfully
benchmark() raised InvalidOperationError: UDF called without return type, but was not able to infer the output type.
output written by the run: False
```

Both blocks ran and **nothing was recorded** — the report does not even come out
empty, it raises, because polars cannot infer types over a frame built from zero
rows.

**On this branch, daisy 1.2.2:**

```
Execution Summary
-----------------

  Task out-lambda:

    num blocks : 2
    completed ✔: 2 (skipped 0)
    failed    ✗: 0
    orphaned  ∅: 0

    all blocks processed successfully
task        init                         Process Block Setup            Acquire Block                  Process Block                  Mark Block Done
out-lambda  0.032s ± 0.0 (idle: 0.002s)  0.008s ± 0.001 (idle: 0.003s)  0.009s ± 0.005 (idle: 0.009s)  0.006s ± 0.001 (idle: 0.001s)  0.004s ± 0.0 (idle: -0.001s)
Benchmark report written to volara_benchmark_report
benchmark() returned cleanly
output written by the run: True
--- io.csv ---
task,init,Process Block Setup,Acquire Block,Process Block,Mark Block Done
out-lambda,read/write: 0.0/0.02 MB,read/write: 0.0/0.0 MB,read/write: 0.0/0.0 MB,read/write: 0.0/0.0 MB,read/write: 0.0/0.0 MB
--- memory.csv ---
task,init,Process Block Setup,Acquire Block,Process Block,Mark Block Done
out-lambda,0.63 MB,3.02 MB,0.07 MB,0.45 MB,0.36 MB
--- time.csv ---
task,init,Process Block Setup,Acquire Block,Process Block,Mark Block Done
out-lambda,0.032s ± 0.0 (idle: 0.002s),0.008s ± 0.001 (idle: 0.003s),0.009s ± 0.005 (idle: 0.009s),0.006s ± 0.001 (idle: 0.001s),0.004s ± 0.0 (idle: -0.001s)
```

Note `output written by the run: True` — this was a real run of the task, not a
dry run, and the worker-loop operations (`Acquire Block`) are in the report, so
the separate `volara-cli` interpreters were traced too.

## Tests

`tests/test_benchmark.py`, 12 tests. Run with `uv`-resolved deps, i.e. daisy
1.2.2, matching CI:

```
$ pytest tests/test_benchmark.py -q -p no:warnings
............                                                             [100%]
12 passed in 9.99s
```

Full suite, no regressions:

```
origin/main (66106bb):  177 passed, 4 skipped, 2 xfailed in 27.05s
this branch:            189 passed, 4 skipped, 2 xfailed in 36.84s
```

The regression that matters,
`test_benchmark_traces_a_worker_config_run[True]`, fails without the log-basedir
fix under daisy 2.0.0 (verified by reverting just that hunk):

```
$ pytest tests/test_benchmark.py::test_benchmark_traces_a_worker_config_run -q -p no:warnings
TypeError: Expected a zarr Array at volara_logs/spoof_out-lambda-meta/blocks_done.zarr, got Group
tests/test_benchmark.py:186: AssertionError: blocks did not run in the worker; recorded [...]
FAILED tests/test_benchmark.py::test_benchmark_traces_a_worker_config_run[True]
1 failed, 1 passed in 11.24s
```

`ruff check volara tests` passes and the four touched files are
`ruff format`-clean.

## Not in this PR

- `Dataset.spoof` rejects `str` stores though `store` is typed `Path | str`, and
  `SQLite.spoof(nodes: bool = True)` is called as `value.spoof(spoof_dir)` — the
  directory arrives as `nodes`. Both block `spoof=True` on the CREMI example;
  see #55. The default (non-spoof) path is unaffected.
- `LUT` has no `spoof`, so `GraphMWS` writes the real lut during a `spoof=True`
  run.
- `examples/benchmarks/benchmark_cremi.py` is untouched; its
  `pipeline.benchmark(multiprocessing=True)` now runs for real rather than
  spoofing, which is the only way it can work at all until #55 lands.
- Three `tests/test_logging.py` tests fail under daisy 2.0.0; they fail on
  `main` under 2.0.0 too and are untouched here.

## Skeptical pass

One bucket: the benchmarking subsystem. The `polars` removal from
`pyproject.toml` is in-bucket because `print_report` was its only consumer — the
dependency exists solely for the code this PR replaces. Nothing else in the diff
is unrelated: `blockwise.py` changes are `get_benchmark_logger`, `benchmark()`,
and the worker log basedir; `pipeline.py` mirrors `benchmark()`. `run_blockwise`
behaviour is unchanged, and `test_run_blockwise_stays_unbenchmarked` and
`test_benchmark_does_not_leak_the_signal` exist to keep it that way.

Left as a draft deliberately.



---

**Update 2026-08-05 — one more fix, and one correction to the table above.**

`benchmark()` called twice in the same interpreter and cwd raised `FileNotFoundError`:
`benchmark_run` wipes `volara_benchmark_logs/traces` on every run, while `_process_trace_file`
caches its handle on `(pid, trace_dir)` — on the second call both matched, so the cache hit skipped
the `mkdir` and returned a path whose directory had just been removed. No test caught it because
every test gets a fresh `tmp_path` cwd, so the cache always missed. Fixed in `a2f14e2`
(reset-on-wipe plus an unconditional `mkdir`), with
`tests/test_benchmark.py::test_benchmark_twice_in_one_process` pinning it — `FileNotFoundError`
before, passing after. Full suite **190 passed, 4 skipped, 2 xfailed**; `ruff` clean.

The correction: the `worker_config` row said "pinned by a test" without qualification. The
`db_path=None` half genuinely is pinned (reverting it fails 6 of 13 tests). The daisy-2.0.0
log-basedir half is **not reachable by CI** — `pyproject.toml` pins `daisy>=1.2.2,<2` — and was
verified by hand. Disabling that hunk leaves every test green, so please read it as a hand-verified
fix, not a CI-guarded one.