### PR TITLE
fix(workers): stop get_slurm_command emitting the worker command twice (every block orphaned)

### DIFF
--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -47,7 +47,13 @@ def cluster_shims(tmp_path, monkeypatch):
 
 def test_slurm_command_is_blocking_srun(cluster_shims):
     """Slurm workers submit via srun: it blocks for the job's lifetime (the spawn
-    contract) and ties the job to the client, unlike fire-and-forget sbatch."""
+    contract) and ties the job to the client, unlike fire-and-forget sbatch.
+
+    Asserted as full-argv equality, not membership: a repeated flag or a repeated
+    trailing worker command is invisible to ``in``/suffix checks, and a doubled
+    worker command is exactly what click rejects with "Got unexpected extra
+    arguments" -- killing every block of every stage.
+    """
     w = workers.SlurmWorker(queue="gpu-q", num_gpus=1, num_cpus=4)
     cmd = w.get_slurm_command(
         command=["volara-cli", "blockwise-worker", "-c", "c.json"],
@@ -56,26 +62,52 @@ def test_slurm_command_is_blocking_srun(cluster_shims):
         num_gpus=1,
         num_cpus=4,
     )
-    assert cmd[0] == "srun", cmd
-    assert "--job-name=mytask" in cmd, cmd
-    assert "--partition=gpu-q" in cmd, cmd
-    assert "--gpus=1" in cmd and "--cpus-per-task=4" in cmd, cmd
     # the worker command rides along as argv (srun has no sbatch-style --wrap)
-    assert cmd[-4:] == ["volara-cli", "blockwise-worker", "-c", "c.json"], cmd
+    assert cmd == [
+        "srun",
+        "--job-name=mytask",
+        "--cpus-per-task=4",
+        "--gpus=1",
+        "--mem=15564",
+        "--partition=gpu-q",
+        "--output=%x_%j.log",
+        "--error=%x_%j.err",
+        "volara-cli",
+        "blockwise-worker",
+        "-c",
+        "c.json",
+    ], cmd
+    assert cmd.count("blockwise-worker") == 1, cmd
     assert not any(a == "sbatch" or a.startswith("--wrap") for a in cmd), cmd
 
 
 def test_lsf_command_is_blocking_bsub(cluster_shims):
-    """LSF workers submit via bsub -K (submit and wait for completion)."""
+    """LSF workers submit via bsub -K (submit and wait for completion).
+
+    Full-argv equality for the same reason as the slurm case above.
+    """
     w = workers.LSFWorker(queue="gpu-q")
     cmd = w.get_lsf_command(
         command=["volara-cli", "blockwise-worker", "-c", "c.json"],
         job_name="mytask",
         queue="gpu-q",
     )
-    assert cmd[:2] == ["bsub", "-K"], cmd
-    assert "-J" in cmd and cmd[cmd.index("-J") + 1] == "mytask", cmd
-    assert cmd[-4:] == ["volara-cli", "blockwise-worker", "-c", "c.json"], cmd
+    assert cmd == [
+        "bsub",
+        "-K",
+        "-J",
+        "mytask",
+        "-n",
+        "1",
+        "-q",
+        "gpu-q",
+        "volara-cli",
+        "blockwise-worker",
+        "-c",
+        "c.json",
+    ], cmd
+    assert cmd.count("blockwise-worker") == 1, cmd
+    assert cmd.count("-J") == 1, cmd
 
 
 def test_get_command_names_job_after_task(cluster_shims, monkeypatch, tmp_path):

--- a/volara/workers.py
+++ b/volara/workers.py
@@ -97,11 +97,9 @@ class SlurmWorker(Worker):
 
         Args:
             command (list[str]): The worker command to run inside the slurm job.
-            command (list[str]): The worker command to run inside the slurm job.
             num_cpus (int, optional): Number of CPU cores per task. Defaults to 1.
             num_gpus (int, optional): Number of GPUs required. Defaults to 0.
             memory (int, optional): Memory allocation (in MB) for the job. Defaults
-                to 15564.
                 to 15564.
             constraint (str, optional): Constraint specification for job
                 execution. Defaults to "".
@@ -109,12 +107,9 @@ class SlurmWorker(Worker):
                 job. Defaults to "".
             job_name (str, optional): Name assigned to the Slurm job. Defaults to "".
             log_file (str | Path | None, optional): Path for standard output logging.
-            log_file (str | Path | None, optional): Path for standard output logging.
                 Defaults to None.
             error_file (str | Path | None, optional): Path for standard error logging.
-            error_file (str | Path | None, optional): Path for standard error logging.
                 Defaults to None.
-            flags (list[str] | None, optional): Additional srun flags as a
             flags (list[str] | None, optional): Additional srun flags as a
                 list. Defaults to None.
 
@@ -129,15 +124,7 @@ class SlurmWorker(Worker):
 
         if job_name:
             run_command.append(f"--job-name={job_name}")
-        self.is_srun_available()
-
-        run_command = ["srun"]
-
-        if job_name:
-            run_command.append(f"--job-name={job_name}")
         run_command.append(f"--cpus-per-task={num_cpus}")
-        if num_gpus > 0:
-            run_command.append(f"--gpus={num_gpus}")
         if num_gpus > 0:
             run_command.append(f"--gpus={num_gpus}")
         run_command.append(f"--mem={memory}")
@@ -145,13 +132,6 @@ class SlurmWorker(Worker):
             run_command.append(f"--partition={queue}")
         if constraint and constraint != "None":
             run_command.append(f"--constraint={constraint}")
-        if constraint and constraint != "None":
-            run_command.append(f"--constraint={constraint}")
-
-        run_command.append(f"--output={log_file}" if log_file else "--output=%x_%j.log")
-        run_command.append(
-            f"--error={error_file}" if error_file else "--error=%x_%j.err"
-        )
 
         run_command.append(f"--output={log_file}" if log_file else "--output=%x_%j.log")
         run_command.append(
@@ -161,8 +141,6 @@ class SlurmWorker(Worker):
         if flags:
             run_command.extend(flags)
 
-        # srun takes the worker command directly (no sbatch-style --wrap)
-        run_command.extend(command)
         # srun takes the worker command directly (no sbatch-style --wrap)
         run_command.extend(command)
 
@@ -233,12 +211,10 @@ class LSFWorker(Worker):
 
         Args:
             command (list[str]): The command to be executed within the LSF job.
-            command (list[str]): The command to be executed within the LSF job.
             num_cpus (int, optional): Number of CPU cores per task. Defaults to 1.
             num_gpus (int, optional): Number of GPUs required. Defaults to 0.
             queue (str, optional): Name of the LSF queue to submit the job.
                 Defaults to "".
-            job_name (str, optional): Name assigned to the LSF job. Defaults to "".
             job_name (str, optional): Name assigned to the LSF job. Defaults to "".
             log_file (str | None, optional): Path for standard output logging.
                 Defaults to None.
@@ -252,11 +228,7 @@ class LSFWorker(Worker):
 
         # -K: submit and wait for the job to complete (the blocking-spawn contract)
         run_command = ["bsub", "-K"]
-        # -K: submit and wait for the job to complete (the blocking-spawn contract)
-        run_command = ["bsub", "-K"]
 
-        if job_name:
-            run_command.extend(["-J", job_name])
         if job_name:
             run_command.extend(["-J", job_name])
         run_command.extend(["-n", str(num_cpus)])


### PR DESCRIPTION
## Why this targets `feat/run-blockwise-states`, not `main`

`main` is not affected. It builds `sbatch --wrap=<command>` and has no duplication. The bug lives
only on `feat/run-blockwise-states`, introduced by that branch's own `srun` refactor (`b412d99`,
duplicated in history as `fa4e97b`). A diff of this against `main` would be unreadable — it would
carry all 21 of the feature branch's commits — which is what sank #40.

This is @pattonw's own suggestion on #40, taken up:

> *If you are depending on a different commit (e.g. daisy-v2 support) you can target that branch for
> merging instead of main so that the diff is clear. If you do that just make it obvious in the
> description of your pull request.*

**This supersedes closed #40** (which targeted `main`, correctly rejected). The diff here is
`volara/workers.py` −28 and `tests/test_workers.py` +42/−10, nothing else.

**Why now, rather than waiting for the squash-into-`b412d99` plan** described when #32 and #40 were
closed: `10f6a87` — this branch's tip — is the exact revision slabreg pins
(`slabreg/pyproject.toml`), and at that revision `worker: slurm` cannot spawn a working worker for
**any** stage. The squash can still happen when the daisy-v2 stack is reopened; that is blocked on
daisy 2.0.0 being installable from PyPI. In the meantime this makes the tip that downstream actually
consumes work. If you would rather this be squashed than merged, say so and I will fold it into
`b412d99` instead — the branch is here either way.

## The bug

`SlurmWorker.get_slurm_command` calls `run_command.extend(command)` twice (`volara/workers.py:165`
and `:167`), so every spawned worker is invoked as:

```
srun … volara-cli blockwise-worker -c cfg volara-cli blockwise-worker -c cfg
```

click rejects that, the worker exits 2 before doing any work, and daisy reports it per block as
`worker function <task> failed`. The driver looks healthy while every block is orphaned — a
full-volume slabreg run lost all 1044 blocks of its first stage twice before the cause turned up in
the worker's own `slurm_worker.err`.

**Exactly one of the duplications is harmful — this one.** The others (`run_command = ["srun"]`
twice, `--gpus`, `--constraint`, `--output`/`--error`, and LSF's `["bsub","-K"]` and `-J`) emit
identical values, so `srun`'s last-wins makes them cosmetic. #40's description claimed the doubled
list init discarded a `--job-name` and that a doubled `--output` redirected the log; both are wrong
and are not repeated here — `--job-name` is re-appended by the second block and appears exactly
once, and the two `--output` values are the same path.

## Reproduction

Runnable as-is; the stub `srun` means no cluster is needed.

```python
import os, stat, tempfile
from volara.workers import SlurmWorker

d = tempfile.mkdtemp()                      # stub `srun` so is_srun_available() passes
p = os.path.join(d, "srun")
open(p, "w").write("#!/usr/bin/env bash\necho slurm-wlm 21.08.0\n")
os.chmod(p, os.stat(p).st_mode | stat.S_IXUSR)
os.environ["PATH"] = d + os.pathsep + os.environ["PATH"]

cmd = SlurmWorker(queue="gpu-q").get_slurm_command(
    command=["volara-cli", "blockwise-worker", "-c", "cfg.json"],
    job_name="mytask", queue="gpu-q",
)
print(" ".join(cmd))
print("blockwise-worker occurrences:", cmd.count("blockwise-worker"))
```

**On `feat/run-blockwise-states` (`10f6a87`):**

```
srun --job-name=mytask --cpus-per-task=1 --mem=15564 --partition=gpu-q --output=%x_%j.log --error=%x_%j.err --output=%x_%j.log --error=%x_%j.err volara-cli blockwise-worker -c cfg.json volara-cli blockwise-worker -c cfg.json
blockwise-worker occurrences: 2
```

**On this branch:**

```
srun --job-name=mytask --cpus-per-task=1 --mem=15564 --partition=gpu-q --output=%x_%j.log --error=%x_%j.err volara-cli blockwise-worker -c cfg.json
blockwise-worker occurrences: 1
```

And what that argv does when click gets it — feeding the emitted tail straight to the CLI group:

```python
import sys
from volara.cli import cli
sys.argv = ["volara-cli", "blockwise-worker", "-c", "cfg.json",
            "volara-cli", "blockwise-worker", "-c", "cfg.json"]   # what the base branch emits
cli()
```

```
Usage: volara-cli blockwise-worker [OPTIONS]
Try 'volara-cli blockwise-worker --help' for help.

Error: Got unexpected extra arguments (volara-cli blockwise-worker)
exit=2
```

With the single-command argv this branch emits, click accepts it and proceeds into config parsing.

## The test change, and why it is in this PR

Without it the suite stays green on the bug. `tests/test_workers.py` asserted
`cmd[-4:] == ["volara-cli", "blockwise-worker", "-c", "c.json"]` — and a command appended **twice**
has exactly that tail, so the assertion passes either way. Same for `"--gpus=1" in cmd` against a
doubled flag. Verified: **3 passed** against the duplicated builder.

Replaced with full-argv list equality plus `cmd.count("blockwise-worker") == 1`, and the equivalent
for the LSF path. slabreg already landed this guard downstream
(`tests/test_slurm_worker.py:105`), so until now the consumer was better protected than the library.

**Before the fix** (strengthened tests, base branch code):

```
$ pytest tests/test_workers.py -q
FF.                                                                      [100%]
E       AssertionError: ['srun', '--job-name=mytask', '--cpus-per-task=4', '--gpus=1', '--gpus=1', '--mem=15564', ...]
E         At index 4 diff: '--gpus=1' != '--mem=15564'
E         Left contains 7 more items, first extra item: 'blockwise-worker'
…
E       AssertionError: ['bsub', '-K', '-J', 'mytask', '-J', 'mytask', ...]
E         At index 4 diff: '-J' != '-n'
E         Left contains 2 more items, first extra item: '-c'
=========================== short test summary info ============================
FAILED tests/test_workers.py::test_slurm_command_is_blocking_srun - Assertion...
FAILED tests/test_workers.py::test_lsf_command_is_blocking_bsub - AssertionEr...
2 failed, 1 passed in 0.12s
```

**After the fix:**

```
$ pytest tests/test_workers.py -q
...                                                                      [100%]
3 passed in 0.04s
```

Full suite on this branch: `81 passed, 4 skipped, 1 xfailed in 14.51s`
(Python 3.13.14, daisy v2).

## Limitation

There is no Slurm or LSF client on the machine this was developed on, so this cannot be exercised
end-to-end — no job was actually submitted. It stays a command-string test: the argv `srun` would be
given is asserted exactly, and the click rejection of the old argv is reproduced against the real
CLI group. What is *not* covered here is that the resulting `srun` invocation succeeds on a real
cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBp6sbdPjq16WvoiWPmH8v
