### PR TITLE
feat(workers)!: submit slurm workers with `sbatch --wait` instead of `srun`

### DIFF
--- a/tests/test_lambda_task.py
+++ b/tests/test_lambda_task.py
@@ -12,8 +12,8 @@ from volara.datasets import Labels, Raw
 from volara.workers import LocalWorker, LSFWorker, SlurmWorker
 
 slurm_available = pytest.mark.skipif(
-    shutil.which("srun") is None or os.environ.get("VOLARA_SLURM_TEST_QUEUE") is None,
-    reason="srun not found or VOLARA_SLURM_TEST_QUEUE not set",
+    shutil.which("sbatch") is None or os.environ.get("VOLARA_SLURM_TEST_QUEUE") is None,
+    reason="sbatch not found or VOLARA_SLURM_TEST_QUEUE not set",
 )
 lsf_available = pytest.mark.skipif(
     shutil.which("bsub") is None or os.environ.get("VOLARA_LSF_TEST_QUEUE") is None,

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -26,8 +26,10 @@ import pytest
 from volara import workers
 
 _BODIES = {
-    # is_srun_available() probes `srun --version`.
-    "srun": 'echo "slurm-wlm 21.08.0"; exit 0',
+    # is_sbatch_available() probes `sbatch --version`.
+    "sbatch": 'echo "slurm-wlm 21.08.0"; exit 0',
+    # scancel is invoked by SlurmWorker.run's teardown.
+    "scancel": 'echo "$@" >> "$SCANCEL_LOG"; exit 0',
     # is_bsub_available() probes `bsub -V` (prints to stderr on real LSF).
     "bsub": 'echo "IBM Spectrum LSF 10.1"; exit 0',
 }
@@ -35,9 +37,11 @@ _BODIES = {
 
 @pytest.fixture()
 def cluster_shims(tmp_path, monkeypatch):
-    """Install fake srun/bsub on PATH so availability probes pass without a cluster."""
+    """Install fake sbatch/scancel/bsub on PATH so the availability probes and the
+    teardown run without a cluster. ``SCANCEL_LOG`` collects what teardown cancelled."""
     bindir = tmp_path / "cluster_shim_bin"
     bindir.mkdir()
+    monkeypatch.setenv("SCANCEL_LOG", str(tmp_path / "scancel.log"))
     for prog, body in _BODIES.items():
         script = bindir / prog
         script.write_text(f"#!/usr/bin/env bash\n{body}\n")
@@ -45,14 +49,18 @@ def cluster_shims(tmp_path, monkeypatch):
     monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ['PATH']}")
 
 
-def test_slurm_command_is_blocking_srun(cluster_shims):
-    """Slurm workers submit via srun: it blocks for the job's lifetime (the spawn
-    contract) and ties the job to the client, unlike fire-and-forget sbatch.
+def test_slurm_command_is_blocking_sbatch_wait(cluster_shims):
+    """Slurm workers submit via ``sbatch --wait``: it blocks for the job's lifetime
+    (the spawn contract) AND submits an independent job, so workers reach the
+    requested partition even when the driver is itself a slurm job.
+
+    ``srun`` also blocks, but inside an allocation it makes a job STEP -- confining
+    every worker to the driver's own nodes and silently ignoring ``--partition``.
 
     Asserted as full-argv equality, not membership: a repeated flag or a repeated
-    trailing worker command is invisible to ``in``/suffix checks, and a doubled
-    worker command is exactly what click rejects with "Got unexpected extra
-    arguments" -- killing every block of every stage.
+    worker command is invisible to ``in``/suffix checks, and a doubled worker command
+    is exactly what click rejects with "Got unexpected extra arguments" -- killing
+    every block of every stage.
     """
     w = workers.SlurmWorker(queue="gpu-q", num_gpus=1, num_cpus=4)
     cmd = w.get_slurm_command(
@@ -62,23 +70,53 @@ def test_slurm_command_is_blocking_srun(cluster_shims):
         num_gpus=1,
         num_cpus=4,
     )
-    # the worker command rides along as argv (srun has no sbatch-style --wrap)
     assert cmd == [
-        "srun",
+        "sbatch",
+        "--wait",
         "--job-name=mytask",
+        "--ntasks=1",
         "--cpus-per-task=4",
         "--gpus=1",
         "--mem=15564",
         "--partition=gpu-q",
         "--output=%x_%j.log",
         "--error=%x_%j.err",
-        "volara-cli",
-        "blockwise-worker",
-        "-c",
-        "c.json",
+        "--wrap=volara-cli blockwise-worker -c c.json",
     ], cmd
-    assert cmd.count("blockwise-worker") == 1, cmd
-    assert not any(a == "sbatch" or a.startswith("--wrap") for a in cmd), cmd
+    assert cmd.count("--wrap=volara-cli blockwise-worker -c c.json") == 1, cmd
+    assert "srun" not in cmd, cmd
+
+
+def test_ntasks_is_exactly_one(cluster_shims):
+    """REGRESSION. Without an explicit ``--ntasks`` slurm derives it from the
+    allocation, so ONE submission expands into that many identical clones sharing a
+    single DAISY_CONTEXT (hence one worker_id, the race daisy warns about) while every
+    later worker blocks on "step creation still disabled". Measured on a 32-CPU driver
+    with num_cpus=4: one step, Tasks=8, and 623 retries."""
+    cmd = workers.SlurmWorker(queue="q", num_cpus=4).get_slurm_command(
+        command=["volara-cli"], num_cpus=4
+    )
+    assert cmd.count("--ntasks=1") == 1, cmd
+
+
+def test_wrap_quotes_arguments_containing_spaces(cluster_shims):
+    """--wrap is a shell string, so a path with a space must survive as one arg."""
+    cmd = workers.SlurmWorker(queue="q").get_slurm_command(
+        command=["volara-cli", "-c", "/a path/c.json"]
+    )
+    assert cmd[-1] == "--wrap=volara-cli -c '/a path/c.json'", cmd
+
+
+def test_time_limit_emitted_only_when_set(cluster_shims):
+    """An independent worker job outlives its client, and a SIGKILLed driver runs no
+    teardown at all -- so ``--time`` is the last bound. Do not assume the cluster has
+    one: partitions may be DefaultTime=NONE / MaxTime=UNLIMITED."""
+    assert not any(
+        a.startswith("--time=")
+        for a in workers.SlurmWorker(queue="q").get_slurm_command(command=["v"])
+    )
+    w = workers.SlurmWorker(queue="q", time_limit="4:00:00")
+    assert "--time=4:00:00" in w.get_slurm_command(command=["v"], time_limit="4:00:00")
 
 
 def test_lsf_command_is_blocking_bsub(cluster_shims):
@@ -122,4 +160,75 @@ def test_get_command_names_job_after_task(cluster_shims, monkeypatch, tmp_path):
     )
 
     cmd = workers.SlurmWorker(queue="gpu-q").get_command(tmp_path / "c.json", "mytask")
-    assert cmd[0] == "srun" and "--job-name=mytask" in cmd, cmd
+    assert cmd[0] == "sbatch" and cmd[1] == "--wait", cmd
+    assert "--job-name=mytask" in cmd, cmd
+
+
+def test_get_command_threads_the_time_limit(cluster_shims, monkeypatch, tmp_path):
+    """time_limit is a field on the worker, so it must reach the emitted command."""
+    import daisy
+
+    monkeypatch.setenv("DAISY_CONTEXT", "worker_id=0:task_id=mytask")
+    monkeypatch.setattr(daisy.logging, "get_worker_log_basename", lambda wid, tid: tmp_path)
+
+    cmd = workers.SlurmWorker(queue="gpu-q", time_limit="2:00:00").get_command(
+        tmp_path / "c.json", "mytask"
+    )
+    assert "--time=2:00:00" in cmd, cmd
+
+
+# ------------------------------------------------------- teardown (scancel by id) ---
+def _fake_sbatch(tmp_path, body):
+    """Rewrite the sbatch shim so a test can script the job's behaviour."""
+    s = tmp_path / "cluster_shim_bin" / "sbatch"
+    s.write_text("#!/usr/bin/env bash\n" + body + "\n")
+    s.chmod(0o755)
+
+
+def test_run_blocks_and_returns_the_jobs_exit_status(cluster_shims, tmp_path):
+    """``sbatch --wait`` returns only when the job ends, and with the job's own exit
+    code -- that IS the blocking-spawn contract, with no polling wrapper. Confirmed
+    against a real scheduler too: rc=7 propagated after a 171 s wait."""
+    _fake_sbatch(tmp_path, 'echo "Submitted batch job 4242"; sleep 0.2; exit 7')
+    assert workers.SlurmWorker(queue="q").run(["sbatch", "--wait"]).returncode == 7
+
+
+def test_run_cancels_its_job_by_id_on_exit(cluster_shims, tmp_path):
+    """The job MUST be cancelled by the client because it does not die with it --
+    measured on a real cluster, NEITHER SIGTERM NOR SIGKILL of ``sbatch --wait`` ends
+    the job. Cancel BY ID: task names are not unique across concurrent runs, so a
+    ``scancel --name`` reap would kill a different run's workers."""
+    _fake_sbatch(tmp_path, 'echo "Submitted batch job 4242"; exit 0')
+    workers.SlurmWorker(queue="q").run(["sbatch", "--wait"])
+    assert (tmp_path / "scancel.log").read_text().split() == ["4242"]
+
+
+def test_run_cancels_the_job_even_when_the_wait_raises(cluster_shims, tmp_path, monkeypatch):
+    """The path that matters: an exception or Ctrl-C mid-run must not strand the job."""
+    import subprocess as sp
+
+    _fake_sbatch(tmp_path, 'echo "Submitted batch job 99"; sleep 30')
+
+    class _Boom(sp.Popen):
+        def wait(self, *a, **k):
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(workers.sp, "Popen", _Boom)
+    with pytest.raises(KeyboardInterrupt):
+        workers.SlurmWorker(queue="q").run(["sbatch", "--wait"])
+    assert (tmp_path / "scancel.log").read_text().split() == ["99"], "job was stranded"
+
+
+def test_unparseable_sbatch_output_warns_rather_than_crashing(cluster_shims, tmp_path, caplog):
+    """If the job id cannot be read the worker still runs -- but say so loudly, because
+    that worker can no longer be cancelled and will run to its time limit."""
+    _fake_sbatch(tmp_path, 'echo "something unexpected"; exit 0')
+    with caplog.at_level("WARNING"):
+        assert workers.SlurmWorker(queue="q").run(["sbatch", "--wait"]).returncode == 0
+    assert "could not parse a slurm job id" in caplog.text
+    assert not (tmp_path / "scancel.log").exists()
+
+
+def test_worker_run_default_is_plain_subprocess_run(cluster_shims):
+    """Non-scheduler backends keep the old behaviour: no job id, no teardown."""
+    assert workers.LocalWorker().run(["true"]).returncode == 0

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -9,10 +9,12 @@ slurm job and any worker that did not cleanly self-exit leaked until walltime, p
 across stages (the observed ~99-node worker storm, reaped by hand with ``scancel --name``).
 
 The fix is to make every backend's submission command itself block for the worker's
-lifetime: a plain child process locally, ``srun`` on slurm (which also ties the job to
-the client: cancelling the driver cancels the steps), and ``bsub -K`` on LSF.
+lifetime: a plain child process locally, ``sbatch --wait`` on slurm, and ``bsub -K`` on
+LSF. Unlike ``srun``, ``sbatch --wait`` does NOT tie the job to the client -- see
+:meth:`SlurmWorker.get_slurm_command` for why that trade is made anyway, and for what
+it costs.
 
-These tests need NO real cluster: fake ``srun``/``bsub`` executables are prepended to
+These tests need NO real cluster: fake ``sbatch``/``bsub`` executables are prepended to
 ``PATH`` so the availability probes succeed and command construction runs for real. A
 ``slurm`` marker is registered in pyproject.toml for any future test that genuinely
 needs a slurm install (run those with ``-m slurm``); none currently do.
@@ -28,8 +30,6 @@ from volara import workers
 _BODIES = {
     # is_sbatch_available() probes `sbatch --version`.
     "sbatch": 'echo "slurm-wlm 21.08.0"; exit 0',
-    # scancel is invoked by SlurmWorker.run's teardown.
-    "scancel": 'echo "$@" >> "$SCANCEL_LOG"; exit 0',
     # is_bsub_available() probes `bsub -V` (prints to stderr on real LSF).
     "bsub": 'echo "IBM Spectrum LSF 10.1"; exit 0',
 }
@@ -37,11 +37,9 @@ _BODIES = {
 
 @pytest.fixture()
 def cluster_shims(tmp_path, monkeypatch):
-    """Install fake sbatch/scancel/bsub on PATH so the availability probes and the
-    teardown run without a cluster. ``SCANCEL_LOG`` collects what teardown cancelled."""
+    """Install fake sbatch/bsub on PATH so availability probes pass without a cluster."""
     bindir = tmp_path / "cluster_shim_bin"
     bindir.mkdir()
-    monkeypatch.setenv("SCANCEL_LOG", str(tmp_path / "scancel.log"))
     for prog, body in _BODIES.items():
         script = bindir / prog
         script.write_text(f"#!/usr/bin/env bash\n{body}\n")
@@ -88,11 +86,15 @@ def test_slurm_command_is_blocking_sbatch_wait(cluster_shims):
 
 
 def test_ntasks_is_exactly_one(cluster_shims):
-    """REGRESSION. Without an explicit ``--ntasks`` slurm derives it from the
-    allocation, so ONE submission expands into that many identical clones sharing a
-    single DAISY_CONTEXT (hence one worker_id, the race daisy warns about) while every
-    later worker blocks on "step creation still disabled". Measured on a 32-CPU driver
-    with num_cpus=4: one step, Tasks=8, and 623 retries."""
+    """One worker submission is exactly one task, pinned rather than inherited.
+
+    ``sbatch`` already defaults to one task, so this is an invariant lock, not a live
+    bug fix. It carries the measured failure it prevents: under the old ``srun`` path,
+    a step inside an allocation took ntasks FROM the allocation, so one submission
+    expanded into that many identical clones sharing a single DAISY_CONTEXT (hence one
+    worker_id, the race daisy warns about) while every later worker blocked on "step
+    creation still disabled" -- 32-CPU driver, num_cpus=4: one step, Tasks=8, 623
+    retries."""
     cmd = workers.SlurmWorker(queue="q", num_cpus=4).get_slurm_command(
         command=["volara-cli"], num_cpus=4
     )
@@ -105,18 +107,6 @@ def test_wrap_quotes_arguments_containing_spaces(cluster_shims):
         command=["volara-cli", "-c", "/a path/c.json"]
     )
     assert cmd[-1] == "--wrap=volara-cli -c '/a path/c.json'", cmd
-
-
-def test_time_limit_emitted_only_when_set(cluster_shims):
-    """An independent worker job outlives its client, and a SIGKILLed driver runs no
-    teardown at all -- so ``--time`` is the last bound. Do not assume the cluster has
-    one: partitions may be DefaultTime=NONE / MaxTime=UNLIMITED."""
-    assert not any(
-        a.startswith("--time=")
-        for a in workers.SlurmWorker(queue="q").get_slurm_command(command=["v"])
-    )
-    w = workers.SlurmWorker(queue="q", time_limit="4:00:00")
-    assert "--time=4:00:00" in w.get_slurm_command(command=["v"], time_limit="4:00:00")
 
 
 def test_lsf_command_is_blocking_bsub(cluster_shims):
@@ -162,73 +152,3 @@ def test_get_command_names_job_after_task(cluster_shims, monkeypatch, tmp_path):
     cmd = workers.SlurmWorker(queue="gpu-q").get_command(tmp_path / "c.json", "mytask")
     assert cmd[0] == "sbatch" and cmd[1] == "--wait", cmd
     assert "--job-name=mytask" in cmd, cmd
-
-
-def test_get_command_threads_the_time_limit(cluster_shims, monkeypatch, tmp_path):
-    """time_limit is a field on the worker, so it must reach the emitted command."""
-    import daisy
-
-    monkeypatch.setenv("DAISY_CONTEXT", "worker_id=0:task_id=mytask")
-    monkeypatch.setattr(daisy.logging, "get_worker_log_basename", lambda wid, tid: tmp_path)
-
-    cmd = workers.SlurmWorker(queue="gpu-q", time_limit="2:00:00").get_command(
-        tmp_path / "c.json", "mytask"
-    )
-    assert "--time=2:00:00" in cmd, cmd
-
-
-# ------------------------------------------------------- teardown (scancel by id) ---
-def _fake_sbatch(tmp_path, body):
-    """Rewrite the sbatch shim so a test can script the job's behaviour."""
-    s = tmp_path / "cluster_shim_bin" / "sbatch"
-    s.write_text("#!/usr/bin/env bash\n" + body + "\n")
-    s.chmod(0o755)
-
-
-def test_run_blocks_and_returns_the_jobs_exit_status(cluster_shims, tmp_path):
-    """``sbatch --wait`` returns only when the job ends, and with the job's own exit
-    code -- that IS the blocking-spawn contract, with no polling wrapper. Confirmed
-    against a real scheduler too: rc=7 propagated after a 171 s wait."""
-    _fake_sbatch(tmp_path, 'echo "Submitted batch job 4242"; sleep 0.2; exit 7')
-    assert workers.SlurmWorker(queue="q").run(["sbatch", "--wait"]).returncode == 7
-
-
-def test_run_cancels_its_job_by_id_on_exit(cluster_shims, tmp_path):
-    """The job MUST be cancelled by the client because it does not die with it --
-    measured on a real cluster, NEITHER SIGTERM NOR SIGKILL of ``sbatch --wait`` ends
-    the job. Cancel BY ID: task names are not unique across concurrent runs, so a
-    ``scancel --name`` reap would kill a different run's workers."""
-    _fake_sbatch(tmp_path, 'echo "Submitted batch job 4242"; exit 0')
-    workers.SlurmWorker(queue="q").run(["sbatch", "--wait"])
-    assert (tmp_path / "scancel.log").read_text().split() == ["4242"]
-
-
-def test_run_cancels_the_job_even_when_the_wait_raises(cluster_shims, tmp_path, monkeypatch):
-    """The path that matters: an exception or Ctrl-C mid-run must not strand the job."""
-    import subprocess as sp
-
-    _fake_sbatch(tmp_path, 'echo "Submitted batch job 99"; sleep 30')
-
-    class _Boom(sp.Popen):
-        def wait(self, *a, **k):
-            raise KeyboardInterrupt
-
-    monkeypatch.setattr(workers.sp, "Popen", _Boom)
-    with pytest.raises(KeyboardInterrupt):
-        workers.SlurmWorker(queue="q").run(["sbatch", "--wait"])
-    assert (tmp_path / "scancel.log").read_text().split() == ["99"], "job was stranded"
-
-
-def test_unparseable_sbatch_output_warns_rather_than_crashing(cluster_shims, tmp_path, caplog):
-    """If the job id cannot be read the worker still runs -- but say so loudly, because
-    that worker can no longer be cancelled and will run to its time limit."""
-    _fake_sbatch(tmp_path, 'echo "something unexpected"; exit 0')
-    with caplog.at_level("WARNING"):
-        assert workers.SlurmWorker(queue="q").run(["sbatch", "--wait"]).returncode == 0
-    assert "could not parse a slurm job id" in caplog.text
-    assert not (tmp_path / "scancel.log").exists()
-
-
-def test_worker_run_default_is_plain_subprocess_run(cluster_shims):
-    """Non-scheduler backends keep the old behaviour: no job id, no teardown."""
-    assert workers.LocalWorker().run(["true"]).returncode == 0

--- a/volara/blockwise/blockwise.py
+++ b/volara/blockwise/blockwise.py
@@ -259,12 +259,7 @@ class BlockwiseTask(StrictBaseModel, ABC):
                 # submission on every backend (local child process, sbatch --wait,
                 # bsub -K); a fire-and-forget submit (bare sbatch/bsub) would trip
                 # the v2 respawn loop and leak the real cluster job.
-                #
-                # Worker.run, not subprocess.run directly: a scheduler job outlives
-                # the client that submitted it, so the backend owns teardown as well
-                # as submission (SlurmWorker.run cancels its job by id on the way
-                # out). The default implementation IS subprocess.run.
-                return worker_config.run(cmd)
+                return subprocess.run(cmd)
 
             return run_worker
 

--- a/volara/blockwise/blockwise.py
+++ b/volara/blockwise/blockwise.py
@@ -256,10 +256,15 @@ class BlockwiseTask(StrictBaseModel, ABC):
                 # BLOCK for the worker's lifetime -- a spawn fn that returns early
                 # is treated as a dead worker and respawned (up to
                 # max_worker_restarts). get_command therefore builds a blocking
-                # submission on every backend (local child process, srun, bsub -K);
-                # a fire-and-forget submit (bare sbatch/bsub) would trip the v2
-                # respawn loop and leak the real cluster job.
-                return subprocess.run(cmd)
+                # submission on every backend (local child process, sbatch --wait,
+                # bsub -K); a fire-and-forget submit (bare sbatch/bsub) would trip
+                # the v2 respawn loop and leak the real cluster job.
+                #
+                # Worker.run, not subprocess.run directly: a scheduler job outlives
+                # the client that submitted it, so the backend owns teardown as well
+                # as submission (SlurmWorker.run cancels its job by id on the way
+                # out). The default implementation IS subprocess.run.
+                return worker_config.run(cmd)
 
             return run_worker
 

--- a/volara/workers.py
+++ b/volara/workers.py
@@ -1,4 +1,6 @@
 import logging
+import re
+import shlex
 import subprocess as sp
 from abc import ABC
 from pathlib import Path
@@ -24,11 +26,31 @@ class Worker(StrictBaseModel, ABC):
         ]
         return cmd
 
+    def run(self, cmd: list[str]) -> sp.CompletedProcess:
+        """Execute one worker submission and BLOCK until that worker exits.
+
+        daisy v2 runs the spawn function in a thread and reads its return as the
+        worker's death (MIGRATION.md, "blocking-spawn contract"), so this must not
+        return early. Backends override it when submitting and owning the process are
+        not the same thing: a scheduler job outlives the client that submitted it, so
+        it must be cleaned up explicitly (see :meth:`SlurmWorker.run`)."""
+        return sp.run(cmd)
+
 
 class SlurmWorker(Worker):
     queue: str
     num_gpus: int = 0
     num_cpus: int = 1
+
+    time_limit: str | None = None
+    """Walltime for each worker job (``--time``), e.g. ``"4:00:00"``.
+
+    Strongly recommended. A worker is an independent slurm job, so it outlives its
+    submitting client; :meth:`run` cancels it on every ordinary exit path, but a
+    SIGKILLed driver runs no cleanup at all and then this is the ONLY bound. Do not
+    assume the cluster provides one -- a partition may be ``DefaultTime=NONE`` /
+    ``MaxTime=UNLIMITED``, in which case an escaped worker runs forever.
+    """
 
     def get_command(self, config_path: Path, task_name: str) -> list[str]:
         cmd = super().get_command(config_path, task_name)
@@ -50,22 +72,67 @@ class SlurmWorker(Worker):
             num_cpus=self.num_cpus,
             log_file=log_file,
             error_file=log_error,
+            time_limit=self.time_limit,
         )
 
-    def is_srun_available(self) -> bool:
+    _JOB_ID = re.compile(r"Submitted batch job (\d+)")
+
+    def run(self, cmd: list[str]) -> sp.CompletedProcess:
+        """Submit one worker with ``sbatch --wait`` and block until the job ends,
+        cancelling it on the way out.
+
+        ``--wait`` gives the blocking-spawn contract natively -- it returns only when
+        the job terminates, and with the job's own exit status -- so no polling wrapper
+        is needed. What it does NOT give is any tie between the job and this client:
+        an independent slurm job survives its submitter, and MEASURED, neither SIGTERM
+        nor SIGKILL of ``sbatch --wait`` cancels it. So the job id is read off sbatch's
+        first line of stdout and ``scancel``-ed in ``finally`` -- on normal exit (a
+        no-op, the job is already gone), on exception, and on ``KeyboardInterrupt``.
+
+        Cancelling BY ID, not by ``--name``: task names are not unique across
+        concurrent runs, so a name-based reap would cancel another run's workers.
+
+        The one path this cannot cover is a SIGKILLed driver, which runs no cleanup at
+        all; :attr:`time_limit` is the bound there."""
+        job_id: str | None = None
+        proc = sp.Popen(cmd, stdout=sp.PIPE, stderr=None, text=True)
+        try:
+            # sbatch prints "Submitted batch job N" immediately, then --wait holds the
+            # pipe open for the job's lifetime -- so read the one line, do NOT drain.
+            first = proc.stdout.readline() if proc.stdout else ""
+            match = self._JOB_ID.search(first or "")
+            if match:
+                job_id = match.group(1)
+                logger.debug("submitted slurm worker job %s", job_id)
+            else:
+                logger.warning(
+                    "could not parse a slurm job id from sbatch output %r; this worker "
+                    "cannot be cancelled on teardown and will run until its time limit",
+                    first,
+                )
+            returncode = proc.wait()
+            return sp.CompletedProcess(cmd, returncode, stdout=first)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+            if job_id is not None:
+                # Already-finished jobs are the normal case; scancel is a no-op there.
+                sp.run(["scancel", job_id], capture_output=True, check=False)
+
+    def is_sbatch_available(self) -> bool:
         try:
             _result = sp.run(
-                ["srun", "--version"], capture_output=True, text=True, check=True
+                ["sbatch", "--version"], capture_output=True, text=True, check=True
             )
             # successful, return True
             return True
         except sp.CalledProcessError as e:
             # errors in the subprocess
-            raise RuntimeError(f"srun failed to execute: {e}") from e
+            raise RuntimeError(f"sbatch failed to execute: {e}") from e
         except FileNotFoundError:
-            # srun is not found in the system's PATH
+            # sbatch is not found in the system's PATH
             raise EnvironmentError(
-                "srun is not installed or not in PATH. Either install slurm on your cluster, or run locally."
+                "sbatch is not installed or not in PATH. Either install slurm on your cluster, or run locally."
             )
 
     def get_slurm_command(
@@ -80,20 +147,30 @@ class SlurmWorker(Worker):
         log_file: str | Path | None = None,
         error_file: str | Path | None = None,
         flags: list[str] | None = None,
+        time_limit: str | None = None,
     ) -> list[str]:
         """
-        Build the ``srun`` line that runs one worker as a slurm job.
+        Build the ``sbatch --wait`` line that runs one worker as its own slurm job.
 
-        ``srun`` rather than ``sbatch``: it submits AND blocks for the job's lifetime,
-        which is daisy v2's spawn contract (MIGRATION.md, "blocking-spawn contract") --
-        ``sbatch`` returns at queue time, so daisy saw every worker as instantly dead,
-        could never reap the real job (terminating the long-gone sbatch client), and
-        leaked workers until walltime. ``srun`` also ties the job to the client:
-        cancelling/killing the driver cancels the job steps with it, so worker jobs
-        cannot outlive the run. Note that ``srun`` inside an existing slurm allocation
-        starts a step WITHIN that allocation rather than submitting a new job --
-        drivers that themselves run as slurm jobs must request resources for their
-        workers up front.
+        ``--wait`` is what makes this satisfy daisy v2's spawn contract (MIGRATION.md,
+        "blocking-spawn contract"): it returns only when the job terminates, and with
+        the job's exit status. A BARE ``sbatch`` returns at queue time, which is the
+        old bug -- daisy saw every worker as instantly dead, respawned, and leaked the
+        real job. ``--wait`` fixes that without a polling wrapper.
+
+        Why not ``srun``: ``srun`` blocks too, and additionally ties the job to the
+        client. But inside an existing allocation it starts a job STEP rather than
+        submitting a new job, so a driver that is itself a slurm job -- the normal way
+        to obtain a GPU node -- can never place workers anywhere but its own
+        allocation, and ``queue``/``--partition`` is silently ignored for them.
+        Measured: a 32-CPU driver requesting 32 workers got ONE step of 8 task clones
+        sharing a single ``DAISY_CONTEXT``, and 623 "step creation still disabled"
+        retries from the workers that never started. That is not a tuning problem, it
+        is the whole fan-out, so ``sbatch --wait`` is the only slurm path.
+
+        The tie to the client is replaced by explicit cleanup: :meth:`SlurmWorker.run`
+        cancels the job by id on every ordinary exit path, and :attr:`time_limit`
+        bounds the one path it cannot cover (a SIGKILLed driver).
 
         Args:
             command (list[str]): The worker command to run inside the slurm job.
@@ -110,20 +187,27 @@ class SlurmWorker(Worker):
                 Defaults to None.
             error_file (str | Path | None, optional): Path for standard error logging.
                 Defaults to None.
-            flags (list[str] | None, optional): Additional srun flags as a
+            flags (list[str] | None, optional): Additional sbatch flags as a
                 list. Defaults to None.
+            time_limit (str | None, optional): Walltime per worker job (``--time``),
+                e.g. "4:00:00". Defaults to None (no limit requested -- see
+                :attr:`SlurmWorker.time_limit` for why you want one).
 
         Returns:
-            list[str]: The srun command, ready for ``subprocess.run``.
+            list[str]: The sbatch command, ready for :meth:`SlurmWorker.run`.
         """
 
         # TODO: raises exception on failure. Maybe handle this gracefully?
-        self.is_srun_available()
+        self.is_sbatch_available()
 
-        run_command = ["srun"]
+        run_command = ["sbatch", "--wait"]
 
         if job_name:
             run_command.append(f"--job-name={job_name}")
+        # ONE task per worker. Without it slurm derives ntasks from the allocation,
+        # which made a single submission expand into N identical clones sharing one
+        # DAISY_CONTEXT (hence one worker_id -- the race daisy warns about).
+        run_command.append("--ntasks=1")
         run_command.append(f"--cpus-per-task={num_cpus}")
         if num_gpus > 0:
             run_command.append(f"--gpus={num_gpus}")
@@ -138,11 +222,15 @@ class SlurmWorker(Worker):
             f"--error={error_file}" if error_file else "--error=%x_%j.err"
         )
 
+        if time_limit:
+            run_command.append(f"--time={time_limit}")
+
         if flags:
             run_command.extend(flags)
 
-        # srun takes the worker command directly (no sbatch-style --wrap)
-        run_command.extend(command)
+        # sbatch runs a batch SCRIPT, so the worker command is handed over as one
+        # shell string. shlex.join keeps arguments containing spaces intact.
+        run_command.append(f"--wrap={shlex.join(command)}")
 
         return run_command
 
@@ -206,8 +294,8 @@ class LSFWorker(Worker):
         ``-K`` makes bsub submit AND block until the job finishes, which is daisy v2's
         spawn contract (MIGRATION.md, "blocking-spawn contract") -- a plain ``bsub``
         returns at queue time, so daisy saw every worker as instantly dead and the
-        real job leaked until walltime (same fire-and-forget bug as slurm's
-        ``sbatch``, fixed there with ``srun``).
+        real job leaked until walltime (same fire-and-forget bug as a bare slurm
+        ``sbatch``, fixed there with ``sbatch --wait``).
 
         Args:
             command (list[str]): The command to be executed within the LSF job.

--- a/volara/workers.py
+++ b/volara/workers.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import shlex
 import subprocess as sp
 from abc import ABC
@@ -26,31 +25,11 @@ class Worker(StrictBaseModel, ABC):
         ]
         return cmd
 
-    def run(self, cmd: list[str]) -> sp.CompletedProcess:
-        """Execute one worker submission and BLOCK until that worker exits.
-
-        daisy v2 runs the spawn function in a thread and reads its return as the
-        worker's death (MIGRATION.md, "blocking-spawn contract"), so this must not
-        return early. Backends override it when submitting and owning the process are
-        not the same thing: a scheduler job outlives the client that submitted it, so
-        it must be cleaned up explicitly (see :meth:`SlurmWorker.run`)."""
-        return sp.run(cmd)
-
 
 class SlurmWorker(Worker):
     queue: str
     num_gpus: int = 0
     num_cpus: int = 1
-
-    time_limit: str | None = None
-    """Walltime for each worker job (``--time``), e.g. ``"4:00:00"``.
-
-    Strongly recommended. A worker is an independent slurm job, so it outlives its
-    submitting client; :meth:`run` cancels it on every ordinary exit path, but a
-    SIGKILLed driver runs no cleanup at all and then this is the ONLY bound. Do not
-    assume the cluster provides one -- a partition may be ``DefaultTime=NONE`` /
-    ``MaxTime=UNLIMITED``, in which case an escaped worker runs forever.
-    """
 
     def get_command(self, config_path: Path, task_name: str) -> list[str]:
         cmd = super().get_command(config_path, task_name)
@@ -72,52 +51,7 @@ class SlurmWorker(Worker):
             num_cpus=self.num_cpus,
             log_file=log_file,
             error_file=log_error,
-            time_limit=self.time_limit,
         )
-
-    _JOB_ID = re.compile(r"Submitted batch job (\d+)")
-
-    def run(self, cmd: list[str]) -> sp.CompletedProcess:
-        """Submit one worker with ``sbatch --wait`` and block until the job ends,
-        cancelling it on the way out.
-
-        ``--wait`` gives the blocking-spawn contract natively -- it returns only when
-        the job terminates, and with the job's own exit status -- so no polling wrapper
-        is needed. What it does NOT give is any tie between the job and this client:
-        an independent slurm job survives its submitter, and MEASURED, neither SIGTERM
-        nor SIGKILL of ``sbatch --wait`` cancels it. So the job id is read off sbatch's
-        first line of stdout and ``scancel``-ed in ``finally`` -- on normal exit (a
-        no-op, the job is already gone), on exception, and on ``KeyboardInterrupt``.
-
-        Cancelling BY ID, not by ``--name``: task names are not unique across
-        concurrent runs, so a name-based reap would cancel another run's workers.
-
-        The one path this cannot cover is a SIGKILLed driver, which runs no cleanup at
-        all; :attr:`time_limit` is the bound there."""
-        job_id: str | None = None
-        proc = sp.Popen(cmd, stdout=sp.PIPE, stderr=None, text=True)
-        try:
-            # sbatch prints "Submitted batch job N" immediately, then --wait holds the
-            # pipe open for the job's lifetime -- so read the one line, do NOT drain.
-            first = proc.stdout.readline() if proc.stdout else ""
-            match = self._JOB_ID.search(first or "")
-            if match:
-                job_id = match.group(1)
-                logger.debug("submitted slurm worker job %s", job_id)
-            else:
-                logger.warning(
-                    "could not parse a slurm job id from sbatch output %r; this worker "
-                    "cannot be cancelled on teardown and will run until its time limit",
-                    first,
-                )
-            returncode = proc.wait()
-            return sp.CompletedProcess(cmd, returncode, stdout=first)
-        finally:
-            if proc.poll() is None:
-                proc.kill()
-            if job_id is not None:
-                # Already-finished jobs are the normal case; scancel is a no-op there.
-                sp.run(["scancel", job_id], capture_output=True, check=False)
 
     def is_sbatch_available(self) -> bool:
         try:
@@ -147,7 +81,6 @@ class SlurmWorker(Worker):
         log_file: str | Path | None = None,
         error_file: str | Path | None = None,
         flags: list[str] | None = None,
-        time_limit: str | None = None,
     ) -> list[str]:
         """
         Build the ``sbatch --wait`` line that runs one worker as its own slurm job.
@@ -168,9 +101,16 @@ class SlurmWorker(Worker):
         retries from the workers that never started. That is not a tuning problem, it
         is the whole fan-out, so ``sbatch --wait`` is the only slurm path.
 
-        The tie to the client is replaced by explicit cleanup: :meth:`SlurmWorker.run`
-        cancels the job by id on every ordinary exit path, and :attr:`time_limit`
-        bounds the one path it cannot cover (a SIGKILLed driver).
+        KNOWN TRADE-OFF, accepted deliberately: what ``srun`` gave for free and this
+        does not is any tie between the job and its client. A worker is now an
+        independent slurm job, and MEASURED on a real cluster, neither ``SIGTERM`` nor
+        ``SIGKILL`` of the ``sbatch --wait`` client ends it -- only ``scancel`` does.
+        So a driver that dies abnormally leaves its workers running until the
+        partition's walltime, and there is no knob here to bound that: ``flags`` is not
+        threaded through :meth:`SlurmWorker.get_command`, so a configured worker cannot
+        yet request ``--time``. On a partition with ``DefaultTime=NONE`` /
+        ``MaxTime=UNLIMITED`` -- the ones measured here -- an escaped worker runs
+        forever, and must be reaped with ``scancel``.
 
         Args:
             command (list[str]): The worker command to run inside the slurm job.
@@ -189,12 +129,9 @@ class SlurmWorker(Worker):
                 Defaults to None.
             flags (list[str] | None, optional): Additional sbatch flags as a
                 list. Defaults to None.
-            time_limit (str | None, optional): Walltime per worker job (``--time``),
-                e.g. "4:00:00". Defaults to None (no limit requested -- see
-                :attr:`SlurmWorker.time_limit` for why you want one).
 
         Returns:
-            list[str]: The sbatch command, ready for :meth:`SlurmWorker.run`.
+            list[str]: The sbatch command, ready for ``subprocess.run``.
         """
 
         # TODO: raises exception on failure. Maybe handle this gracefully?
@@ -204,9 +141,11 @@ class SlurmWorker(Worker):
 
         if job_name:
             run_command.append(f"--job-name={job_name}")
-        # ONE task per worker. Without it slurm derives ntasks from the allocation,
-        # which made a single submission expand into N identical clones sharing one
-        # DAISY_CONTEXT (hence one worker_id -- the race daisy warns about).
+        # ONE task per worker, pinned explicitly. This is the failure the srun path
+        # hit: as a step inside an allocation, ntasks came from the allocation, so a
+        # single submission expanded into N identical clones sharing one
+        # DAISY_CONTEXT (hence one worker_id -- the race daisy warns about). sbatch
+        # defaults to 1, so this pins the invariant rather than fixing a live bug.
         run_command.append("--ntasks=1")
         run_command.append(f"--cpus-per-task={num_cpus}")
         if num_gpus > 0:
@@ -221,9 +160,6 @@ class SlurmWorker(Worker):
         run_command.append(
             f"--error={error_file}" if error_file else "--error=%x_%j.err"
         )
-
-        if time_limit:
-            run_command.append(f"--time={time_limit}")
 
         if flags:
             run_command.extend(flags)


### PR DESCRIPTION
> **For @pattonw to decide.** This changes how every slurm worker is submitted, and it removes the `srun` path rather than adding a mode beside it. Your call whether it belongs on this branch.

**BREAKING:** the `srun` submission path is removed. Slurm workers are now submitted with `sbatch --wait`.

> **Changed 2026-08-07, after @pattonw's review.** The teardown harness this PR originally carried is **gone** — see [What was removed](#what-was-removed-2026-08-07) at the bottom. This is now the submission change and nothing else.

## Why srun has to go

`srun` blocks, which is why it was chosen — but inside an existing allocation it creates a job **step**, not a new job. A driver that is itself a slurm job (the normal way to get a GPU node) therefore can never place workers anywhere but its own allocation, and `queue`/`--partition` is silently ignored for them.

Measured on a 32-CPU driver requesting 32 workers:

```
$ squeue -s -j 6677
6677.32   ...                       # ONE worker step
$ scontrol show step 6677.32
   Nodes=1 CPUs=32 Tasks=8          # 8 clones of one submission
$ grep -c "step creation still disabled" driver.log
623                                 # the other 31 workers, permanently blocked
```

Those 8 clones share a single `DAISY_CONTEXT`, hence one `worker_id` — the race daisy warns about in its own log line. Blocks still completed, so this degrades silently rather than failing. `num_workers` buys nothing.

That isn't a tuning problem; it's the whole fan-out. And it can't be fixed by launching differently — `sbatch` for the driver *is* the normal case.

## `sbatch --wait` satisfies the contract natively

The reason srun was picked over bare `sbatch` was *"no need for a custom wrapper around `subprocess.run()` with polling by process name."* `--wait` needs no wrapper either: it returns only when the job terminates, with the job's own exit status. Verified against a real scheduler:

```
$ time sbatch --wait --wrap="sleep 20; exit 7"
   → blocked 171s, returned rc=7
```

`blockwise.py` only requires the spawn command to block, so this is a drop-in — `subprocess.run(cmd)` is unchanged, and `blockwise.py`'s diff is now a **comment correction only**.

## The whole change

- `get_slurm_command` builds `sbatch --wait … --wrap=<command>` instead of `srun … <command>`. `shlex.join` for `--wrap`, since it is a shell string and a path with a space must survive as one argument.
- `--ntasks=1`, pinned explicitly. `sbatch` already defaults to one task, so this locks an invariant rather than fixing a live bug — but the failure it locks out is the measured one above, where a step took `ntasks` from the allocation.
- `is_srun_available` → `is_sbatch_available`.

Plus three things this PR falsified and had missed: the `tests/test_workers.py` module docstring still described `srun` as the fix, `tests/test_lambda_task.py` gated its real-cluster slurm test on `shutil.which("srun")`, and the `--ntasks` comment attributed the allocation-derived-ntasks behaviour to `sbatch` when it was measured for `srun` steps.

## The trade-off, stated plainly

`srun` tied the job to the client for free. An independent job does not, and **neither signal propagates** (measured on a real cluster, 25 s after each):

| action on the `sbatch --wait` client | worker job |
|---|---|
| `SIGKILL` | still `RUNNING` |
| `SIGTERM` | still `RUNNING` |
| `scancel <id>` | terminated |

So a driver that dies abnormally leaves its workers running until the partition's walltime, and there is **no knob here to bound that** — `flags` is not threaded through `SlurmWorker.get_command`, so a configured worker cannot request `--time` today. On the partitions measured here (`DefaultTime=NONE` / `MaxTime=UNLIMITED`) an escaped worker runs until reaped by hand with `scancel`.

This is recorded, not argued: it is documented in `get_slurm_command`'s docstring so the next reader finds it, and bounding it is a separate PR if wanted.

## Tests

5 worker tests (was 3): full-argv equality for the `sbatch --wait` line, `--ntasks=1` as a named regression carrying the measured failure mode, `shlex` quoting through `--wrap`, the LSF line, and `get_command` end to end.

```
tests/test_workers.py     5 passed
tests/                    183 passed, 4 skipped, 2 xfailed, 3 failed
```

The 3 failures are all in `tests/test_logging.py`, are **pre-existing** (reproduced on a clean clone of the base with identical errors), and are unchanged by rebuilding daisy to `b323d78` — I checked, since `KeyError: 'logdir'` looked like it might be a stale-daisy artifact. It isn't. `ruff check` and `ruff format` are both at exact base parity (1 pre-existing error, 4 pre-existing unformatted files).

## One thing worth knowing before this is useful

On our cluster this change is necessary but not sufficient: the installed daisy predated `7128d9c` *"Advertise an address workers can reach; stop binding loopback."* srun-as-steps put every worker on the driver's own node, where loopback resolves — so the step bug was **masking** the daisy bug. The moment workers land on other nodes they must be able to reach the driver. Anyone adopting this needs daisy ≥ `7128d9c`.

<a name="what-was-removed-2026-08-07"></a>

## What was removed 2026-08-07

@pattonw: *"I don't know if we need a large harness around the worker to make sure volara can kill it."* Removed, in `cf720a6`:

- the `Worker.run()` backend hook — dead code once `SlurmWorker.run` goes, no other backend overrode it
- `SlurmWorker.run()` — `Popen`, the job-id parse off sbatch's first stdout line, `scancel` in `finally`
- `blockwise.py` back to calling `subprocess.run(cmd)` directly
- `SlurmWorker.time_limit` and the `--time` flag, which existed **only** as the backstop for the one path teardown could not cover (a SIGKILLed driver runs no cleanup at all)
- the 5 teardown tests and the 2 `time_limit` tests

To answer the question directly, since it deserves an answer: the harness was never about a zombie *process* — the `sbatch --wait` client dies normally. It was about the slurm **job**, which survives its client; the table above is the measurement. So the MWE would have been "kill the driver, `squeue` still shows the workers." That is now an accepted cost rather than a mitigated one, and it is documented in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zvvAtcrDLNYu3uFBgw4Hm
