### PR TITLE
fix(workers): resolve volara-cli from sys.executable, not the worker's PATH

### DIFF
--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,0 +1,45 @@
+"""Worker command construction.
+
+The worker command is built in the DRIVER but executed on a scheduler node, in a shell the
+driver does not control -- so anything it resolves by name is resolved against the worker's
+environment, not the driver's.
+"""
+
+import sys
+from pathlib import Path
+
+from volara import workers
+
+
+# ------------------------------------------------- volara-cli resolution (PATH-proof) ---
+def test_worker_command_pins_the_cli_beside_this_interpreter(monkeypatch):
+    """A bare ``volara-cli`` resolves against the WORKER's PATH, not the driver's. A
+    scheduler starts the job in a fresh login shell, so it can pick up a different
+    environment -- typically a base conda env with a stale volara missing task
+    entry-points -- and the worker then fails task-union validation while the driver
+    waits forever for a worker that can never succeed."""
+    # LocalWorker.get_command reads the daisy worker context; supply one so this test
+    # needs no running daisy server.
+    monkeypatch.setenv("DAISY_CONTEXT", "worker_id=0:task_id=t")
+    expected = str(Path(sys.executable).parent / "volara-cli")
+    cmd = workers.LocalWorker().get_command(Path("/tmp/c.json"), "t")
+    if Path(expected).is_file():
+        assert cmd[0] == expected, cmd
+    else:  # no sibling CLI in this environment -> documented PATH fallback
+        assert cmd[0] == "volara-cli", cmd
+    assert cmd[1:] == ["blockwise-worker", "-c", "/tmp/c.json"], cmd
+
+
+def test_cli_falls_back_to_the_bare_name_when_there_is_no_sibling(monkeypatch, tmp_path):
+    """Unusual layouts (zipapp, shim on PATH, scripts installed elsewhere) must keep
+    working exactly as before rather than pointing at a path that does not exist."""
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "nonesuch" / "python"))
+    assert workers.Worker.volara_cli() == "volara-cli"
+
+
+def test_cli_is_absolute_when_a_sibling_exists(monkeypatch, tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "volara-cli").write_text("#!/usr/bin/env bash\n")
+    monkeypatch.setattr(sys, "executable", str(fake_bin / "python"))
+    assert workers.Worker.volara_cli() == str(fake_bin / "volara-cli")

--- a/volara/workers.py
+++ b/volara/workers.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess as sp
+import sys
 from abc import ABC
 from pathlib import Path
 
@@ -17,12 +18,31 @@ class Worker(StrictBaseModel, ABC):
 
     def get_command(self, config_path: Path, task_name: str) -> list[str]:
         cmd = [
-            "volara-cli",
+            self.volara_cli(),
             "blockwise-worker",
             "-c",
             str(config_path),
         ]
         return cmd
+
+    @staticmethod
+    def volara_cli() -> str:
+        """Absolute path to the ``volara-cli`` beside the RUNNING interpreter, falling
+        back to a bare ``volara-cli`` when there is none.
+
+        A bare name resolves against the WORKER's ``PATH``, which is not the driver's:
+        a scheduler starts the job in a fresh login shell, so it can pick up a
+        different environment entirely -- typically a base conda env whose volara is
+        stale and missing task entry-points. The worker then fails task-union
+        validation and the driver waits forever for a worker that can never succeed.
+        Resolving against ``sys.executable`` makes the worker environment independent
+        of the job's ``PATH`` and conda activation.
+
+        The fallback keeps unusual layouts working (a zipapp, a shim on PATH, an
+        interpreter whose scripts live elsewhere): if there is no sibling CLI, emit the
+        bare name and let PATH decide, exactly as before."""
+        candidate = Path(sys.executable).parent / "volara-cli"
+        return str(candidate) if candidate.is_file() else "volara-cli"
 
 
 class SlurmWorker(Worker):


### PR DESCRIPTION
Minimal, self-contained, and independent of the daisy-v2 line — this applies equally to `main` and to the migration branch.

## The bug

The worker command is built in the **driver** and executed on a **scheduler node**, in a shell the driver does not control. So a bare `volara-cli` resolves against the *worker's* `PATH` — and a scheduler starts the job in a fresh login shell, which commonly picks up a different environment entirely, typically a base conda env whose volara is stale and missing task entry-points.

The worker then fails pydantic's task-union validation and exits, and the driver waits forever for a worker that can never succeed. No crash, no progress — one observed instance orphaned 512 blocks with the driver looking healthy.

## The fix

```python
@staticmethod
def volara_cli() -> str:
    candidate = Path(sys.executable).parent / "volara-cli"
    return str(candidate) if candidate.is_file() else "volara-cli"
```

Resolving beside the running interpreter makes the worker environment independent of the job's `PATH` and conda activation. The fallback keeps unusual layouts working — zipapp, a PATH shim, an interpreter whose scripts live elsewhere — so behaviour is unchanged wherever there is no sibling script.

## Why it's worth doing upstream

Downstream (slabreg) has been carrying this as a `SlurmWorker` subclass that overrides `get_command` **purely to substitute `argv[0]`**. That subclass has broken twice:

- it once inlined a *copy* of `get_slurm_command`, which silently rotted when the signature changed and killed a full run;
- it drops any newly added kwarg, because it enumerates them by name — which just cost a walltime bound on a GPU fleet.

Neither failure would exist if the CLI resolved itself. With this merged, that subclass can be deleted.

## Tests

Adds `tests/test_workers.py` (new file on `main`): the pinned absolute path, the documented bare-name fallback, and the resulting argv.

```
tests/test_workers.py    3 passed
tests/                   177 passed, 4 skipped, 2 xfailed, 3 failed
```

The 3 failures are all `tests/test_logging.py` and are **pre-existing on `main`** — untouched by this PR, which changes only `argv[0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)