### PR TITLE
test(logging): pin the daisy-v2 spawn-path logdir contract instead of the 1.x every-Context form

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,7 +2,7 @@
 
 volara spawns each worker as a fresh ``volara-cli`` PROCESS, so nothing that lives only in
 a module-global reaches it.  ``BlockwiseTask.process_blocks`` recovers the driver's basedir
-from ``daisy.Client().context["logdir"]`` (``volara/blockwise/blockwise.py:260``) -- i.e.
+from ``daisy.Client().context["logdir"]`` (``volara/blockwise/blockwise.py:284``) -- i.e.
 volara depends on **daisy** to carry it across the boundary, in the ``DAISY_CONTEXT``
 environment variable.
 
@@ -12,13 +12,20 @@ worker that disagree about it address *different* done-marker stores, the worker
 ``open_ds(..., mode="a")`` creates a zarr Group where an Array is expected, and the run
 orphans **every** block while the driver log stays clean.
 
-It has already broken once: daisy v2 dropped ``logdir`` from the worker context and replaced
-it with a fallback that reads the process-global basedir -- correct for a *forked* worker,
-wrong for a spawned one.  Fixed upstream in funkelab/daisy@505e7be.
+WHERE daisy carries it moved in daisy 2.0, and these tests pin the new place.  daisy 1.x
+put ``logdir`` on every ``Context`` at construction; daisy 2.0 injects it only when
+``DAISY_CONTEXT`` is built for a spawned worker (``context_with_logdir()`` in
+``daisy/_worker_processes.py``), reading the driver's ``daisy.logging`` global -- which
+``volara.logging.set_log_basedir`` forwards to.  A bare ``daisy.Context(...)`` never
+carries ``logdir`` under v2, so asserting the 1.x form means asserting a contract daisy
+no longer offers anywhere.  What volara actually relies on is the spawn path, and that is
+what is pinned here.
 
-There was no test in volara crossing a process boundary at all, which is why a change to
-someone else's contract could do that silently.  These tests pin the contract volara
-actually relies on, so the next change to it fails here instead of in a full-volume run.
+The end-to-end form of the same contract -- a real spawned ``volara-cli`` worker marking
+blocks done in the store the driver prepared -- is already exercised by every
+multiprocessing test in this suite: ``tests/conftest.py``'s autouse ``logdir`` fixture
+points each test at a private basedir, so a worker that fell back to the default would
+address a different ``blocks_done`` store and fail those tests loudly.
 """
 
 import json
@@ -34,15 +41,29 @@ from volara.logging import get_log_basedir, set_log_basedir
 
 
 def _context(**kwargs):
-    """A worker context as the driver builds it."""
+    """A worker context as daisy's server builds it -- ``logdir``-less under v2."""
     return daisy.Context(hostname="localhost", port=1234, task_id="t", worker_id=0, **kwargs)
+
+
+def _spawn_context():
+    """The context exactly as daisy hands it to a spawned worker.
+
+    ``context_with_logdir`` is what daisy applies when it builds ``DAISY_CONTEXT`` for a
+    worker subprocess.  It is private, and importing it here is deliberate: volara's
+    worker reads what that function wrote, so if daisy renames or reshapes it, volara
+    wants to find out from this file rather than from a full-volume run.
+    """
+    from daisy._worker_processes import context_with_logdir
+
+    return context_with_logdir(_context())
 
 
 def test_volara_set_log_basedir_reaches_the_daisy_context(tmp_path):
     """The driver's basedir must appear in the context daisy hands to workers.
 
-    This is the assumption ``blockwise.py:260`` depends on. It is daisy's to provide, and
-    volara has no fallback if it stops -- so it is worth asserting from this side.
+    This is the assumption ``blockwise.py:284`` depends on.  Under daisy 2.0 it holds at
+    the spawn boundary, not at construction -- both halves are asserted, so this cannot
+    drift back to the 1.x form that no longer exists.
 
     pytest tests/test_logging.py::test_volara_set_log_basedir_reaches_the_daisy_context
     """
@@ -50,29 +71,31 @@ def test_volara_set_log_basedir_reaches_the_daisy_context(tmp_path):
     set_log_basedir(basedir)
     assert get_log_basedir() == basedir
 
-    # daisy stores the Path itself in the context object and stringifies it in to_env(),
-    # so compare as paths here and as strings in the serialized test below.
-    assert Path(_context()["logdir"]) == basedir, (
-        "daisy's worker context does not carry the driver's log basedir; every spawned "
-        "worker will resolve a different meta_dir and address a different blocks_done store"
+    # v2 semantics: a bare Context carries no logdir; only the spawn path adds it.
+    assert "logdir" not in _context()
+
+    assert Path(_spawn_context()["logdir"]) == basedir, (
+        "daisy's spawn-path context does not carry the driver's log basedir; every "
+        "spawned worker will resolve a different meta_dir and address a different "
+        "blocks_done store"
     )
 
 
 def test_the_basedir_survives_serialization_to_the_environment(tmp_path, monkeypatch):
     """``logdir`` must survive the round-trip that actually crosses the boundary.
 
-    Being in the context object is not enough -- it reaches a worker only through
-    ``DAISY_CONTEXT``, so the encoded form is what matters.
+    Being in the spawn-path context object is not enough -- it reaches a worker only
+    through ``DAISY_CONTEXT``, so the encoded form is what matters.
 
     pytest tests/test_logging.py::test_the_basedir_survives_serialization_to_the_environment
     """
     basedir = tmp_path / "driver_basedir"
     set_log_basedir(basedir)
 
-    encoded = _context().to_env()
+    encoded = _spawn_context().to_env()
     assert "logdir" in encoded, encoded
 
-    # from_env() is the only decoder daisy 1.x exposes, so go through the env var -- which
+    # from_env() is the decoder the worker side uses, so go through the env var -- which
     # is the real transport anyway.
     monkeypatch.setenv(daisy.Context.ENV_VARIABLE, encoded)
     assert Path(daisy.Context.from_env()["logdir"]) == basedir
@@ -81,9 +104,9 @@ def test_the_basedir_survives_serialization_to_the_environment(tmp_path, monkeyp
 def test_a_spawned_process_recovers_the_drivers_basedir(tmp_path):
     """A real child process must resolve the basedir its parent set.
 
-    The genuine cross-boundary check, and the one that was missing: a fresh interpreter
-    reading only ``DAISY_CONTEXT`` from its environment, exactly as ``volara-cli
-    blockwise-worker`` does.
+    The genuine cross-boundary check: a fresh interpreter reading only ``DAISY_CONTEXT``
+    from its environment, exactly as ``volara-cli blockwise-worker`` does -- with that
+    variable holding what daisy's spawn path puts there.
 
     pytest tests/test_logging.py::test_a_spawned_process_recovers_the_drivers_basedir
     """
@@ -91,7 +114,7 @@ def test_a_spawned_process_recovers_the_drivers_basedir(tmp_path):
     set_log_basedir(basedir)
 
     env = dict(os.environ)
-    env[daisy.Context.ENV_VARIABLE] = _context().to_env()
+    env[daisy.Context.ENV_VARIABLE] = _spawn_context().to_env()
     # Deliberately NOT inheriting the parent's module state: a fresh import, like a worker.
     child = subprocess.run(
         [sys.executable, "-c", "import daisy, json;"


### PR DESCRIPTION
Fixes the three `tests/test_logging.py` failures that keep all six of #58's CI test legs red ([diagnosis comment](https://github.com/e11bio/volara/pull/58#issuecomment-5198769959)). Test-only change; no library code is touched.

### Why the tests were red

The tests asserted daisy **1.x**'s contract: every `Context` carries `logdir` at construction. daisy **2.0** (this branch's pin) no longer offers that contract anywhere:

- a bare `daisy.Context(...)` is the Rust `PyContext` and injects nothing (`daisy-py/src/py_context.rs:27-39` at `v2.0` tip `b323d78`);
- `logdir` is injected only when `DAISY_CONTEXT` is built for a **spawned worker**: `context_with_logdir()` at `daisy-py/python/daisy/_worker_processes.py:118-144`, applied at `:247`, reading the driver's `daisy.logging` global — which `volara.logging.set_log_basedir` forwards to (`volara/logging.py:25`).

So the failures were by design, not a regression: `KeyError: 'logdir'` on a context daisy never claims to decorate.

The contract volara actually relies on still holds. The worker-side consumer, `blockwise.py:284` (`set_log_basedir(client.context["logdir"])`), runs inside a spawned worker — exactly the covered path — and daisy's own `tests/test_worker_execution.py:232-265` and `:269-310` assert a spawned worker (and even a re-exec'ed grandchild) recovers the driver's basedir. End-to-end, this suite already exercises it under a custom basedir on every multiprocessing test, because `tests/conftest.py`'s autouse `logdir` fixture points each test at a private basedir — a worker falling back to the default would address a different `blocks_done` store and fail those tests.

### The port

Each in-process test now pins the **spawn-path** form via a `_spawn_context()` helper; the first test also asserts that a bare `Context` carries **no** `logdir`, so the file cannot drift back to the 1.x form. `test_a_spawned_process_recovers_the_drivers_basedir` keeps its real-child-process check, with `DAISY_CONTEXT` holding what daisy's spawn path puts there. `test_a_worker_without_a_context_does_not_silently_guess` is unchanged.

`_spawn_context()` deliberately imports daisy's private `daisy._worker_processes.context_with_logdir`: volara's worker reads what that function wrote, so if daisy renames or reshapes it, volara should find out from this file rather than from a full-volume run (rationale in the helper's docstring).

### Reproduction

Env: `uv sync --extra dev --extra indirect`, Python 3.13.13, daisy 2.0.0 resolved from `v2.0` @ `b323d78` (contains funkelab/daisy@505e7be).

**On the base branch (`will/rbws-plus-main` @ `8a78749`):**
```console
$ uv run pytest tests/test_logging.py -q
FAILED tests/test_logging.py::test_volara_set_log_basedir_reaches_the_daisy_context
  - KeyError: 'logdir'   # Path(_context()["logdir"])
FAILED tests/test_logging.py::test_the_basedir_survives_serialization_to_the_environment
  - AssertionError: assert 'logdir' in 'task_id=t:worker_id=0:port=1234:hostname=localhost'
FAILED tests/test_logging.py::test_a_spawned_process_recovers_the_drivers_basedir
  - CalledProcessError (child: KeyError: 'logdir')
3 failed, 1 passed
```

**On this branch:**
```console
$ uv run pytest tests/test_logging.py -q
4 passed
```

**Full suite:** base `3 failed, 183 passed, 4 skipped, 2 xfailed` → this branch **`186 passed, 4 skipped, 2 xfailed`**.

### Not included

The `Python Lint` leg's `extract_frags.py` F401 already has a one-click suggestion on #58 — separate change, deliberately not folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QGnabZYYcDs5NLMtnMq8t
