### PR TITLE
feat(workers): let a SlurmWorker ask for memory

### DIFF
--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -152,3 +152,45 @@ def test_get_command_names_job_after_task(cluster_shims, monkeypatch, tmp_path):
     cmd = workers.SlurmWorker(queue="gpu-q").get_command(tmp_path / "c.json", "mytask")
     assert cmd[0] == "sbatch" and cmd[1] == "--wait", cmd
     assert "--job-name=mytask" in cmd, cmd
+
+
+def test_get_command_requests_the_workers_configured_memory(
+    cluster_shims, monkeypatch, tmp_path
+):
+    """REGRESSION. `get_slurm_command` has always accepted `memory=`, but `get_command` -- the path
+    daisy actually spawns workers through -- never passed one, so EVERY SlurmWorker silently got the
+    15564 MB default with no way to ask for more.
+
+    That is not a tuning nicety: it caps what a blockwise task can do at all. A task whose block is
+    large cannot run on a worker, and pushing such a task onto the fan-out path moves the
+    computation to a machine SMALLER than the driver it came from. e11bio/volara-surface's
+    whole-face surface postprocess hit exactly this -- a 134 GiB computation dispatched to a 15.2 G
+    worker."""
+    import daisy
+
+    monkeypatch.setenv("DAISY_CONTEXT", "worker_id=0:task_id=mytask")
+    monkeypatch.setattr(
+        daisy.logging, "get_worker_log_basename", lambda wid, tid: tmp_path
+    )
+
+    cmd = workers.SlurmWorker(queue="q", memory=131072).get_command(
+        tmp_path / "c.json", "mytask"
+    )
+    assert "--mem=131072" in cmd, cmd
+    assert "--mem=15564" not in cmd, cmd
+
+
+def test_worker_memory_defaults_to_the_historical_value(
+    cluster_shims, monkeypatch, tmp_path
+):
+    """The new field must not change any existing pipeline: a worker that says nothing about memory
+    still asks for exactly what it asked for before."""
+    import daisy
+
+    monkeypatch.setenv("DAISY_CONTEXT", "worker_id=0:task_id=mytask")
+    monkeypatch.setattr(
+        daisy.logging, "get_worker_log_basename", lambda wid, tid: tmp_path
+    )
+
+    cmd = workers.SlurmWorker(queue="q").get_command(tmp_path / "c.json", "mytask")
+    assert "--mem=15564" in cmd, cmd

--- a/volara/workers.py
+++ b/volara/workers.py
@@ -30,12 +30,6 @@ class SlurmWorker(Worker):
     queue: str
     num_gpus: int = 0
     num_cpus: int = 1
-    # Memory per worker, MB. `get_slurm_command` has always taken a `memory=` argument, but
-    # `get_command` never passed one -- so EVERY SlurmWorker got the 15564 MB default and there was
-    # no way to ask for more. That silently caps what a blockwise task can do: a task whose block is
-    # large (e11bio/volara-surface's whole-face surface postprocess is one) cannot run on a worker at
-    # all, and forcing it onto the fan-out path just moves the computation to a SMALLER machine than
-    # the driver it came from. Default unchanged, so existing pipelines are unaffected.
     memory: int = 15564
 
     def get_command(self, config_path: Path, task_name: str) -> list[str]:

--- a/volara/workers.py
+++ b/volara/workers.py
@@ -30,6 +30,13 @@ class SlurmWorker(Worker):
     queue: str
     num_gpus: int = 0
     num_cpus: int = 1
+    # Memory per worker, MB. `get_slurm_command` has always taken a `memory=` argument, but
+    # `get_command` never passed one -- so EVERY SlurmWorker got the 15564 MB default and there was
+    # no way to ask for more. That silently caps what a blockwise task can do: a task whose block is
+    # large (e11bio/volara-surface's whole-face surface postprocess is one) cannot run on a worker at
+    # all, and forcing it onto the fan-out path just moves the computation to a SMALLER machine than
+    # the driver it came from. Default unchanged, so existing pipelines are unaffected.
+    memory: int = 15564
 
     def get_command(self, config_path: Path, task_name: str) -> list[str]:
         cmd = super().get_command(config_path, task_name)
@@ -49,6 +56,7 @@ class SlurmWorker(Worker):
             queue=self.queue,
             num_gpus=self.num_gpus,
             num_cpus=self.num_cpus,
+            memory=self.memory,
             log_file=log_file,
             error_file=log_error,
         )


### PR DESCRIPTION
`get_slurm_command` has always accepted a `memory=` argument. `get_command` — the path daisy
actually spawns workers through — never passed one. So **every** `SlurmWorker` silently got the
15564 MB default, and there was no way to ask for more.

## Why this is a ceiling, not a tuning nicety

It caps what a blockwise task can do *at all*. A task whose block is large cannot run on a worker,
and dispatching such a task to the fan-out path moves the computation to a machine **smaller than
the driver it came from**.

The case that surfaced it: `volara-surface`'s surface postprocess has a whole-face `write_roi`, so
`VOLARA_SURFACE_DISPATCH=blockwise` decomposes it into exactly one block. On a 24414×25016 face that
block needed **~134 GiB**. It was dispatched to a **15.2 G** worker. Forcing blockwise looked like
the fix for a driver OOM and could never have worked — the same computation, on 1/8th the machine.

## The change

One field on `SlurmWorker`, threaded through `get_command`. **Default unchanged**, so no existing
pipeline moves.

```python
class SlurmWorker(Worker):
    queue: str
    num_gpus: int = 0
    num_cpus: int = 1
    memory: int = 15564   # new
```

## Gates

| test | guards |
|---|---|
| `test_get_command_requests_the_workers_configured_memory` | a configured `memory` reaches `--mem` — **verified to FAIL when the passthrough line is removed**, which is the whole change |
| `test_worker_memory_defaults_to_the_historical_value` | an unconfigured worker still asks for exactly 15564, so nobody's pipeline shifts under them |

7 tests in `test_workers.py` pass.

## Scope note

**Not touching `LSFWorker`.** `get_lsf_command` takes no memory argument at all, so the equivalent
there means changing the command builder itself, and I have no LSF cluster to test against. Flagging
rather than guessing.

Based on `will/rbws-plus-main` (where #59 landed) rather than `main`, since that is the v2 line this
pipeline runs.