### PR TITLE
fix: blockwise tasks never resume — check_function always raises on daisy v2

### DIFF
--- a/tests/test_lut.py
+++ b/tests/test_lut.py
@@ -1,6 +1,23 @@
+import fsspec
 import numpy as np
+import pytest
 
 from volara.lut import LUT, LUTS
+
+
+@pytest.fixture
+def fake_s3(monkeypatch):
+    """
+    Back `LUT._s3fs` with an in-memory fsspec filesystem so that s3 code
+    paths can be exercised without a bucket.
+    """
+    fs = fsspec.filesystem("memory")
+    fs.store.clear()
+    fs.pseudo_dirs.clear()
+    monkeypatch.setattr(LUT, "_s3fs", lambda self: fs)
+    yield fs
+    fs.store.clear()
+    fs.pseudo_dirs.clear()
 
 
 def test_lut_save_load(tmp_path):
@@ -54,6 +71,83 @@ def test_luts_load(tmp_path):
     loaded = luts.load()
     assert loaded.shape == (2, 4)
     np.testing.assert_array_equal(loaded, [[1, 2, 3, 4], [10, 20, 30, 40]])
+
+
+def test_lut_uri_local(tmp_path):
+    """`uri` is the normalized local path for non-s3 luts."""
+    lut = LUT(path=str(tmp_path / "local"))
+    assert not lut.is_s3
+    assert lut.uri == str(tmp_path / "local.npz")
+    assert lut.name == "local"
+
+
+def test_lut_s3_save_load(fake_s3):
+    lut = LUT(path="s3://bucket/path/to/data.zarr/lut.npz")
+    assert lut.is_s3
+    assert lut.uri == "s3://bucket/path/to/data.zarr/lut.npz"
+    assert lut.name == "lut"
+    assert not lut.exists()
+    assert lut.load() is None
+
+    data = np.array([[1, 2, 3], [10, 20, 30]])
+    lut.save(data)
+    assert lut.exists()
+    np.testing.assert_array_equal(lut.load(), data)
+
+
+def test_lut_s3_save_load_with_edges(fake_s3):
+    lut = LUT(path="s3://bucket/lut.npz")
+    data = np.array([[1, 2], [10, 20]])
+    edges = np.array([[1, 2, 0.5]])
+    lut.save(data, edges=edges)
+    np.testing.assert_array_equal(lut.load(), data)
+
+
+def test_lut_s3_extension_appended(fake_s3):
+    lut = LUT(path="s3://bucket/path/to/data.zarr/lut")
+    assert lut.uri == "s3://bucket/path/to/data.zarr/lut.npz"
+    lut.save(np.array([[1], [2]]))
+    assert fake_s3.exists("s3://bucket/path/to/data.zarr/lut.npz")
+
+
+def test_lut_s3_drop(fake_s3):
+    lut = LUT(path="s3://bucket/lut.npz")
+    lut.save(np.array([[1], [2]]))
+    assert lut.exists()
+    lut.drop()
+    assert not lut.exists()
+    # dropping a missing lut is a no-op
+    lut.drop()
+
+
+def test_lut_s3_file_raises(fake_s3):
+    """s3 luts have no local path."""
+    lut = LUT(path="s3://bucket/lut.npz")
+    with pytest.raises(ValueError, match="no local path"):
+        lut.file
+
+
+def test_luts_mixed_local_and_s3(tmp_path, fake_s3):
+    """Local and s3 luts can be combined."""
+    local = LUT(path=tmp_path / "a.npz")
+    remote = LUT(path="s3://bucket/b.npz")
+    local.save(np.array([[1, 2], [10, 20]]))
+    remote.save(np.array([[10, 20], [100, 200]]))
+
+    luts = local + remote
+    np.testing.assert_array_equal(luts.load(), [[1, 2, 10, 20], [10, 20, 100, 200]])
+    iterated = luts.load_iterated()
+    np.testing.assert_array_equal(iterated[0], [1, 2])
+    np.testing.assert_array_equal(iterated[1], [100, 200])
+
+
+def test_luts_load_skips_missing(tmp_path):
+    """Missing luts are skipped rather than breaking concatenation."""
+    lut_a = LUT(path=tmp_path / "a.npz")
+    lut_b = LUT(path=tmp_path / "missing.npz")
+    lut_a.save(np.array([[1, 2], [10, 20]]))
+    loaded = LUTS(luts=[lut_a, lut_b]).load()
+    np.testing.assert_array_equal(loaded, [[1, 2], [10, 20]])
 
 
 def test_luts_load_iterated(tmp_path):

--- a/volara/blockwise/blockwise.py
+++ b/volara/blockwise/blockwise.py
@@ -391,7 +391,8 @@ class BlockwiseTask(StrictBaseModel, ABC):
                 read_write_conflict=self.read_write_conflict,
                 fit=self.fit,
                 num_workers=self.num_workers,
-                check_function=self.check_block_func(),
+                # Under meta_dir so drop() still clears the done state.
+                tracking_path=str(self.meta_dir / "daisy_tracking"),
                 max_retries=2,
                 timeout=None,
                 upstream_tasks=(

--- a/volara/lut.py
+++ b/volara/lut.py
@@ -1,5 +1,6 @@
+import io
 from collections.abc import Sequence
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import numpy as np
 
@@ -15,16 +16,59 @@ class LUT(StrictBaseModel):
 
     path: Path | str
     """
-    The path at which we will read/write the look up table
+    The path at which we will read/write the look up table. Either a local
+    path (`/path/to/data.zarr/lut.npz`) or an s3 uri
+    (`s3://bucket/path/to/data.zarr/lut.npz`). The `.npz` extension will be
+    appended if it is missing from a string path.
+    """
+
+    s3_kwargs: dict | None = None
+    """
+    Optional config for S3-compatible stores like Lyve Cloud.
+    Leave as None for standard S3 behavior (credentials from the environment).
+    Only used when `path` is an `s3://` uri.
     """
 
     @property
+    def is_s3(self) -> bool:
+        """
+        Whether this look up table lives in an s3 bucket rather than on
+        the local filesystem.
+        """
+        return isinstance(self.path, str) and self.path.startswith("s3://")
+
+    def _s3fs(self):
+        import s3fs  # type: ignore[unresolved-import]
+
+        if self.s3_kwargs is None:
+            return s3fs.S3FileSystem()
+
+        return s3fs.S3FileSystem(**self.s3_kwargs)
+
+    @property
+    def uri(self) -> str:
+        """
+        The normalized location of this look up table as a string. This is
+        the only accessor that works for both local and s3 look up tables.
+        """
+        if self.is_s3:
+            path = str(self.path)
+            return path if path.endswith(".npz") else f"{path}.npz"
+        return str(self.file)
+
+    @property
     def name(self) -> str:
+        if self.is_s3:
+            return PurePosixPath(self.uri).stem
         return self.file.stem
 
     @property
     def file(self) -> Path:
         if isinstance(self.path, str):
+            if self.is_s3:
+                raise ValueError(
+                    f"{self.path} is an s3 uri and has no local path, use `uri` instead"
+                )
             return (
                 Path(self.path)
                 if self.path.endswith(".npz")
@@ -35,27 +79,55 @@ class LUT(StrictBaseModel):
         else:
             raise TypeError(f"Invalid type for path ({self.path}): {type(self.path)}")
 
+    def exists(self) -> bool:
+        if self.is_s3:
+            return self._s3fs().exists(self.uri)
+        return self.file.exists()
+
     def drop(self):
-        if self.file.exists():
+        if self.is_s3:
+            fs = self._s3fs()
+            try:
+                fs.rm(self.uri)
+            except FileNotFoundError:
+                pass
+            fs.invalidate_cache(self.uri)
+        elif self.file.exists():
             self.file.unlink()
 
     def save(self, lut: np.ndarray, edges=None):
+        arrays = {"fragment_segment_lut": lut.astype(int)}
         if edges is not None:
-            np.savez_compressed(
-                self.file, fragment_segment_lut=lut.astype(int), edges=edges
-            )
+            arrays["edges"] = edges
+
+        if self.is_s3:
+            fs = self._s3fs()
+            with fs.open(self.uri, "wb") as f:
+                np.savez_compressed(f, **arrays)
+            fs.invalidate_cache(self.uri)
         else:
-            np.savez_compressed(self.file, fragment_segment_lut=lut.astype(int))
+            np.savez_compressed(self.file, **arrays)
 
     def load(self) -> np.ndarray | None:
+        if self.is_s3:
+            fs = self._s3fs()
+            if not fs.exists(self.uri):
+                return None
+            with fs.open(self.uri, "rb") as f:
+                buffer = io.BytesIO(f.read())
+            with np.load(buffer) as data:
+                return data["fragment_segment_lut"]
+
         if not self.file.exists():
             return None
-        return np.load(self.file)["fragment_segment_lut"]
+        with np.load(self.file) as data:
+            return data["fragment_segment_lut"]
 
     def __add__(self, other):
         """
-        Add two disjoint LUTs together via simple concatenation.
-        i.e. {0:1} + {1:2} = {0:2}
+        Add two disjoint LUTs together. See `LUTS.load` for concatenation of
+        disjoint mappings i.e. {0:1} + {2:3} = {0:1, 2:3}, and
+        `LUTS.load_iterated` for chaining mappings i.e. {0:1} + {1:2} = {0:2}.
         """
         if isinstance(other, LUT):
             return LUTS(luts=[self, other])
@@ -68,14 +140,15 @@ class LUTS:
 
     def __add__(self, other):
         if isinstance(other, LUTS):
-            return LUTS(self.luts + other.luts)
+            return LUTS(list(self.luts) + list(other.luts))
         elif isinstance(other, LUT):
             return LUTS(list(self.luts) + [other])
         raise TypeError(f"Cannot add {type(other)} to LUTS")
 
     def load(self):
+        mappings = (lut.load() for lut in self.luts)
         return np.concatenate(
-            [lut.load() for lut in self.luts if lut.load() is not None], axis=1
+            [mapping for mapping in mappings if mapping is not None], axis=1
         )  # type: ignore
 
     def load_iterated(self):


### PR DESCRIPTION
`check_function` raises on every block, so no block is ever seen as done and every rerun recomputes everything.

### Reproduction

One daisy task, 64 blocks, run twice. Second run should skip all 64.

```python
def check_block(block):                                  # volara/blockwise/blockwise.py:204-215
    block_array = open_ds(block_ds_path, mode="r")
    coordinate = (block.write_roi.offset - block_array.offset) / block_array.voxel_size
    ...

task = daisy.Task(..., check_function=check_block)
daisy.run_blockwise([task], multiprocessing=False)       # twice
```

**On `main`:**
```
run 1: process_function called on 64 blocks
run 2: process_function called on 64 blocks
check received block.write_roi.offset of type: daisy._daisy.Coordinate
check RAISED: TypeError: unsupported operand type(s) for -: 'daisy._daisy.Coordinate' and 'Coordinate'
```

**On this branch:**
```
run 1: process_function called on 64 blocks
run 2: process_function called on 0 blocks
Execution Summary:  blocks 64   completed 64   skipped 64
```

### Cause

daisy v2's compat layer wraps `process_function` so it receives a funlib-typed `Block`
(`daisy/v1_compat.py:221-225`) but does not wrap `check_function`. `check_block` therefore gets a
native `Block`, and `blockwise.py:209` evaluates `daisy._daisy.Coordinate - funlib.geometry.Coordinate`:

```python
>>> daisy.Coordinate((0,0,0)) - funlib.geometry.Coordinate((1,1,1))
TypeError: unsupported operand type(s) for -: 'daisy._daisy.Coordinate' and 'Coordinate'
```

The scheduler catches a raising check as "not done", so the failure is silent.

### Fix

Use daisy's built-in done-markers rather than checking `blocks_done.zarr` through `check_function`.
`tracking_path` is under `meta_dir`, so `drop()` still clears the done state and rerun semantics are
unchanged — markers outside `meta_dir` would survive a drop and skip everything.

`blocks_done.zarr` is left in place; removing it is a separate change.

### Tests

`3 failed, 182 passed` on both `main` and this branch — the three `test_logging` failures are
pre-existing and unrelated.

Related: funkelab/daisy#80 wraps `check_function` upstream, which fixes released volara versions too.
These are complementary.