### PR TITLE
feat(datasets): Dataset.flip reverses axes of the final array

### DIFF
--- a/tests/test_dataset_flip.py
+++ b/tests/test_dataset_flip.py
@@ -1,0 +1,111 @@
+"""`Dataset.flip` reverses axes of the FINAL array, and travels in the config.
+
+The point of a declared field rather than a wrapper: a blockwise worker rebuilds the model from
+`model_dump_json()` and calls `array()` itself, so the reversal applies there too. A subclass or an
+in-memory wrapper applies in the driver and silently not in the worker.
+"""
+
+import numpy as np
+import pytest
+from funlib.geometry import Coordinate, Roi
+from funlib.persistence import prepare_ds
+
+from volara.datasets import Raw
+
+
+def _store(tmp_path, shape, name="t.zarr"):
+    p = tmp_path / name
+    arr = prepare_ds(
+        p, shape=shape, dtype=np.uint16, voxel_size=(1,) * len(shape),
+        offset=(0,) * len(shape), axis_names=list("tczyx"[-len(shape):]),
+        units=["nm"] * len(shape), mode="w",
+    )
+    data = np.arange(int(np.prod(shape)), dtype=np.uint16).reshape(shape)
+    arr[:] = data
+    return p, data
+
+
+def test_flip_reverses_the_named_axis(tmp_path):
+    p, data = _store(tmp_path, (6, 5, 4))
+    r = Raw(store=p, flip=[0], voxel_size=(1, 1, 1), offset=(0, 0, 0))
+    assert np.array_equal(np.asarray(r.array("r")[:]), data[::-1])
+
+
+def test_flip_takes_several_axes(tmp_path):
+    p, data = _store(tmp_path, (6, 5, 4))
+    r = Raw(store=p, flip=[0, 2], voxel_size=(1, 1, 1), offset=(0, 0, 0))
+    assert np.array_equal(np.asarray(r.array("r")[:]), data[::-1, :, ::-1])
+
+
+def test_flip_indexes_the_array_AFTER_channels(tmp_path):
+    """The whole ndim trap: on a 5-D store `z` is axis 2, but axis 0 once channels collapse."""
+    p, data = _store(tmp_path, (2, 3, 6, 5, 4))
+    r = Raw(store=p, channels=[1, 2], flip=[0], voxel_size=(1,) * 5, offset=(0,) * 5)
+    got = np.asarray(r.array("r")[:])
+    assert got.shape == (6, 5, 4)
+    assert np.array_equal(got, data[1, 2][::-1])
+
+
+def test_sub_roi_reads_through_the_reversal_are_exact(tmp_path):
+    """A blockwise worker reads BLOCKS, so whole-array correctness is not enough."""
+    p, data = _store(tmp_path, (12, 5, 4))
+    ref = data[::-1]
+    arr = Raw(store=p, flip=[0], voxel_size=(1, 1, 1), offset=(0, 0, 0)).array("r")
+    for z0, zs in ((0, 3), (3, 4), (8, 4), (5, 2), (10, 2)):
+        got = np.asarray(arr[Roi(Coordinate(z0, 0, 0), Coordinate(zs, 5, 4))])
+        assert np.array_equal(got, ref[z0:z0 + zs]), f"z[{z0}:{z0 + zs}]"
+
+
+def test_the_field_survives_a_round_trip_through_json(tmp_path):
+    """This is the property the whole design rests on: the flip reaches a worker."""
+    p, data = _store(tmp_path, (6, 5, 4))
+    r = Raw(store=p, channels=None, flip=[0, 2], voxel_size=(1, 1, 1), offset=(0, 0, 0))
+    rebuilt = Raw.model_validate_json(r.model_dump_json())
+    assert rebuilt.flip == [0, 2]
+    assert np.array_equal(np.asarray(rebuilt.array("r")[:]), data[::-1, :, ::-1])
+
+
+def test_a_task_typed_field_keeps_the_flip(tmp_path):
+    """A `Raw`-typed field on a task model must not erase it -- a SUBCLASS would be erased here."""
+    from pydantic import BaseModel
+
+    class _Task(BaseModel):
+        intensities: Raw
+
+    p, data = _store(tmp_path, (6, 5, 4))
+    t = _Task(intensities=Raw(store=p, flip=[0], voxel_size=(1, 1, 1), offset=(0, 0, 0)))
+    rebuilt = _Task.model_validate_json(t.model_dump_json())
+    assert rebuilt.intensities.flip == [0]
+    assert np.array_equal(np.asarray(rebuilt.intensities.array("r")[:]), data[::-1])
+
+
+def test_no_flip_is_byte_identical_to_before(tmp_path):
+    p, data = _store(tmp_path, (6, 5, 4))
+    for flip in (None, []):
+        r = Raw(store=p, flip=flip, voxel_size=(1, 1, 1), offset=(0, 0, 0))
+        assert np.array_equal(np.asarray(r.array("r")[:]), data)
+
+
+def test_an_out_of_range_axis_raises_naming_the_final_ndim(tmp_path):
+    """`flip` indexes the FINAL array; a store-axis index is the mistake to catch."""
+    p, _ = _store(tmp_path, (2, 3, 6, 5, 4))
+    r = Raw(store=p, channels=[1, 2], flip=[4], voxel_size=(1,) * 5, offset=(0,) * 5)
+    with pytest.raises(ValueError, match=r"out of range for the 3-D array"):
+        r.array("r")
+
+
+def test_a_write_mode_is_refused_up_front(tmp_path):
+    """`is_writeable` reports True through a slice lazy op and `__setitem__` then raises."""
+    p, _ = _store(tmp_path, (6, 5, 4))
+    r = Raw(store=p, flip=[0], voxel_size=(1, 1, 1), offset=(0, 0, 0))
+    with pytest.raises(ValueError, match="read-only"):
+        r.array("a")
+
+
+def test_cloudvolume_refuses_rather_than_ignoring(tmp_path):
+    """It overrides array() without the lazy-op path, so a flip there would be silently inert."""
+    from volara.datasets import CloudVolumeWrapper
+
+    cv = CloudVolumeWrapper(store="gs://nonexistent/x", flip=[0])
+    with pytest.raises(NotImplementedError, match="does not apply flip"):
+        cv.array("r")

--- a/volara/blockwise/extract_frags.py
+++ b/volara/blockwise/extract_frags.py
@@ -14,7 +14,6 @@ from scipy.ndimage import (
     gaussian_filter,
     label,
     maximum_filter,
-    measurements,
 )
 from skimage.measure import label as relabel
 from skimage.morphology import remove_small_objects

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -33,6 +33,20 @@ class Dataset(StrictBaseModel, ABC):
     units: list[str] | None = None
     writable: bool = True
 
+    flip: list[int] | None = None
+    """
+    Axis indices to reverse, applied AFTER `channels` has collapsed any leading axes -- so
+    they index the FINAL array, not the store. For a `[T,C,Z,Y,X]` store read with
+    `channels=[0, 0]` the result is `[Z,Y,X]` and `flip=[0]` reverses Z.
+
+    Read-only: a reversed array reports `is_writeable` True but `__setitem__` raises, so a
+    write mode is refused up front rather than at the first write.
+
+    Corrects a volume acquired in a flipped orientation, so that nothing downstream needs to
+    know. It is a lazy slice, not a copy, and it travels in this config -- a worker that
+    rebuilds the model applies the same reversal, which an in-memory wrapper would not.
+    """
+
     channels: list[list[int] | int] | int | None = None
     """
     We want to be able to subsample channels from a dataset. Specifically
@@ -211,6 +225,26 @@ class Dataset(StrictBaseModel, ABC):
                         arr.lazy_op(np.s_[channels])
             else:
                 arr.lazy_op(np.s_[self.channels])
+
+        if self.flip:
+            if mode != "r":
+                raise ValueError(
+                    f"Dataset {self.store} has flip={self.flip}, which is read-only; "
+                    f"cannot open in mode {mode!r}."
+                )
+            ndim = len(arr.shape)
+            bad = [a for a in self.flip if not 0 <= a < ndim]
+            if bad:
+                raise ValueError(
+                    f"flip={self.flip} has axes {bad} out of range for the {ndim}-D array "
+                    f"remaining after channels={self.channels}. flip indexes the FINAL array."
+                )
+            rev = set(self.flip)
+            arr.lazy_op(
+                tuple(
+                    slice(None, None, -1) if i in rev else slice(None) for i in range(ndim)
+                )
+            )
         return arr
 
     @property
@@ -364,6 +398,18 @@ class CloudVolumeWrapper(Dataset):
 
     def array(self, mode: OpenMode = "r") -> Array:
         import dask.array as da
+
+        # This override does not call `lazy_ops` and does not apply `channels`, so neither can
+        # take effect here. Refusing is loud; ignoring them would be a silently different array
+        # from the one the same config produces for every other Dataset.
+        unsupported = [
+            n for n in ("flip", "channels") if getattr(self, n, None) not in (None, [])
+        ]
+        if unsupported:
+            raise NotImplementedError(
+                f"CloudVolumeWrapper does not apply {', '.join(unsupported)}; it overrides "
+                f"array() without the lazy-op path. Drop the field or use a zarr-backed Dataset."
+            )
 
         vol = CloudVolume(
             str(self.store),


### PR DESCRIPTION
Adds `Dataset.flip: list[int] | None` — axis indices to reverse — so a volume acquired in a flipped orientation can be corrected by declaration rather than by materialising a corrected copy.

Motivation is slabreg: a gel slab is sometimes imaged upside down, and today that is handled by producing a duplicate volume outside the pipeline. That costs a full copy of the data and leaves the correction invisible in the config that describes the dataset.

### Why a field, and not a wrapper or a subclass

A blockwise worker rebuilds the task model from `model_dump_json()` and calls `array()` itself. A **declared field travels**; an in-memory wrapper does not. Neither does a `Dataset` subclass — assigned to a `Raw`-typed task field the subclass survives in memory, but `model_dump()` drops the added field and the round-trip returns a plain `Raw`:

```
direct dump keeps flip:                     True
after assignment to a `Raw`-typed field:    RawFlipped   # still the subclass, in memory
serialised keys include flip:               False        # <-- dropped here
round-tripped type:  Raw  | flip survives:  GONE
```

That applies in the driver and **silently not under slurm**, which is the worst possible split — it passes exactly the smoke test you would run first. Two tests pin the travelling property directly, one through a `Raw`-typed task field.

`channels` is the existence proof that this shape works: it is already a declared field whose lazy op survives the hop.

### Three deliberate choices

- **Applied after the `channels` collapse**, not in `lazy_ops` — `lazy_ops` runs at `:203`, *before* the channels block at `:205-213`, so a flip there would land on the timepoint/channel axes of a 5-D store. The indices name the **final** array: `[T,C,Z,Y,X]` read with `channels=[0,0]` is `[Z,Y,X]`, and `flip=[0]` reverses Z. There is a test for exactly this.
- **A slice tuple, not a callable**, so funlib keeps its introspectable fusion path (and this does not copy the late-binding closure over the loop variable at `:209`).
- **On `Dataset`, not `Raw`**, so `Dataset.spoof()` carries it for `BlockwiseTask.benchmark()`.

### Read-only, and one companion fix

A reversed array reports `is_writeable` True while `__setitem__` raises, so a non-`"r"` mode is refused up front rather than at the first write.

`CloudVolumeWrapper.array()` fully overrides `Dataset.array()` and applies neither `lazy_ops` nor `channels`, so a base-class `flip` would be **silently inert** there — the exact failure this design exists to avoid, relocated. It now refuses `flip` and `channels` by name. That also surfaces a pre-existing silent ignore of `channels`.

### Verification

10 new tests: single and multi-axis reversal; indices resolve against the post-`channels` array; **sub-ROI reads are exact** (a worker reads blocks, so whole-array correctness is not enough); round-trip through JSON and through a task-typed field; `flip=None`/`[]` byte-identical to before; out-of-range axis raises naming the final ndim; write mode refused; CloudVolume refuses.

The existing suite is **25 failed / 164 passed both with and without this change** on this branch — a daisy API mismatch against the checkout's venv (`tracking_path`, `init_block_array`), pre-existing and unrelated. Verified by exporting the unmodified base with `git archive` and running both.

Targets `will/rbws-plus-main` because that is the branch slabreg pins (`uv.lock`: `?branch=will%2Frbws-plus-main`), not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbGpCGKwenjmLG6quBEw6Y

---

### ⚠️ CI state on this branch, before you read the red marks

**`will/rbws-plus-main` is already failing CI on its own head** — `gh run list --branch will/rbws-plus-main` shows `Python Ruff: failure` and `ty: failure`. This PR inherits that; it does not cause it.

- **Ruff** — was one unused `scipy.ndimage.measurements` import in `extract_frags.py`, a file this PR does not otherwise touch. Fixed here in a separate commit, because leaving the PR red for a reason that is not its own is worse than a one-line drive-by. Ruff now passes.
- **`ty` and the `test-*` matrix** — pre-existing and not mine. The test failures are a daisy API mismatch (`'DummyTask' object has no attribute 'init_block_array'`, `KeyError: 'logdir'`, `Task.__new__() got an unexpected keyword argument 'tracking_path'`), which is what this branch's daisy pin does against the current suite.

**Evidence that this change adds nothing:** I exported the unmodified base with `git archive` (not `cp -a` — a worktree's `.git` is a pointer file and a copy writes through to the real branch) and ran both trees against the same interpreter:

```
base (origin/will/rbws-plus-main, unmodified):  25 failed, 164 passed, 4 skipped, 1 xfailed
this branch, excluding its own new tests:       25 failed, 164 passed, 4 skipped, 1 xfailed
this branch's new tests:                        10 passed
```

Identical counts, same named failures. `ruff check` on the two files this PR authors: clean.
