### PR TITLE
fix(datasets): Raw.stack survives serialisation

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -161,6 +161,34 @@ def test_lazy_stacking(zarr_store, second_zarr_store):
     assert np.all(data[2:4] == 2.0)
 
 
+def test_stack_survives_a_config_round_trip(zarr_store, second_zarr_store):
+    """A worker rebuilds its task from `config.json`, so a field that does not serialise fails
+    there and only there. Annotated with the abstract base, `stack` dumped only `Dataset`'s own
+    fields -- dropping `scale_shift` -- and came back with no discriminator to pick a class from.
+    """
+    base = Raw(store=zarr_store, stack=Raw(store=second_zarr_store, scale_shift=(2.0, 0.0)))
+
+    back = Raw.model_validate_json(base.model_dump_json())
+
+    assert isinstance(back.stack, Raw)
+    assert back.stack.scale_shift == (2.0, 0.0)
+    # and the rebuilt dataset still stacks: 2.0 scaled by 2.0, on the base's 1.0
+    data = back.array()[:]
+    assert data.shape == (4, 10, 10)
+    assert np.all(data[0:2] == 1.0) and np.all(data[2:4] == 4.0)
+
+
+def test_a_stacked_dataset_keeps_its_own_class_through_the_round_trip(zarr_store,
+                                                                      second_zarr_store):
+    """`stack` is typed as any dataset, not as `Raw`, so the discriminator has to choose -- which
+    is what a plain `Raw | None` annotation would not do."""
+    base = Raw(store=zarr_store, stack=Labels(store=second_zarr_store))
+
+    back = Raw.model_validate_json(base.model_dump_json())
+
+    assert isinstance(back.stack, Labels)
+
+
 # --- Test Category 3: Attributes ---
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -159,6 +161,22 @@ def test_lazy_stacking(zarr_store, second_zarr_store):
     assert np.all(data[0:2] == 1.0)
     # Next 2 channels should be 2.0 (stacked)
     assert np.all(data[2:4] == 2.0)
+
+
+def test_raw_is_a_complete_model_at_import():
+    """`stack` names a union defined below `Raw`, so it arrives as a string annotation. Pydantic
+    would resolve it on first use, leaving `model_fields` showing a ForwardRef until then; the
+    explicit `model_rebuild()` resolves it at import instead.
+
+    In a fresh interpreter on purpose: validating a `Raw` anywhere earlier in this session resolves
+    the ForwardRef, so an in-process assert would pass with the rebuild removed.
+    """
+    out = subprocess.run(
+        [sys.executable, "-c", "from volara.datasets import Raw;"
+         "print(Raw.__pydantic_complete__, 'ForwardRef' in repr(Raw.model_fields['stack'].annotation))"],
+        capture_output=True, text=True, check=True)
+
+    assert out.stdout.split() == ["True", "False"], out.stdout
 
 
 def test_stack_survives_a_config_round_trip(zarr_store, second_zarr_store):

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -302,7 +302,7 @@ class Raw(Dataset):
     dataset_type: Literal["raw"] = "raw"
     ome_norm: Path | str | None = None
     scale_shift: tuple[float, float] | None = None
-    stack: Dataset | None = None
+    stack: "PydanticDataset | None" = None
 
     @property
     def bounds(self) -> list[tuple[float, float]] | None:

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -495,3 +495,9 @@ PydanticDataset = Annotated[
     Union[Raw, Affs, LSD, Labels, CloudVolumeWrapper],
     Field(discriminator="dataset_type"),
 ]
+
+# `Raw.stack` names this union, which is defined below `Raw` and so reaches it as a string. Pydantic
+# resolves that on first use, but until then `Raw.__pydantic_complete__` is False and the field's
+# annotation is still a ForwardRef -- so anything reading `model_fields` early sees the unresolved
+# form.
+Raw.model_rebuild()


### PR DESCRIPTION
Closes #68. **Low priority — nothing reachable depends on it** (see Scope).

`Raw.stack` was annotated with the abstract base, so pydantic serialised it *as* a `Dataset` and
emitted only that class's fields: `dataset_type`, `ome_norm`, `scale_shift` and any nested `stack`
were dropped. Coming back, `Dataset` is an ABC with no discriminator, so validation tried to
instantiate it and raised `TypeError: Can't instantiate abstract class Dataset ...` — a bare
`TypeError`, not a `ValidationError`, so it does not present as a config problem.

That is the path every worker takes (`blockwise` writes `model_dump_json()` to `config.json`, the
worker CLI validates it back) for **any** non-`None` `worker_config`. Only the in-process default
escapes, which is why it stayed quiet.

### Fix

`stack: "PydanticDataset | None"` — the discriminated union that already exists, as a string
because it is defined below `Raw`. `Raw | None` would also fix the dump, but `stack` accepts any
dataset and the union preserves that (second test pins a `Labels` member).

Second commit adds `Raw.model_rebuild()`: without it the string annotation leaves
`Raw.__pydantic_complete__` False and the field a bare `ForwardRef` until first use. Its test runs
in a subprocess because validating a `Raw` earlier in the session would resolve the reference and
mask the regression.

### Scope

Nothing outside tests passes `stack=` anywhere in the ecosystem, and the failure is **loud** — a
dropped `stack` can never validate back into a usable object, so there is no silently-wrong-result
path. This is a public field that crashes under a worker, not a bug that is biting. Land it as
cheap hygiene or close it as YAGNI; I would land it because it is one line and already verified.

Two side effects, neither reachable while nothing passes `stack=`: `Raw.model_json_schema()` is now
`$ref`-rooted (intrinsic to any self-referential field, not to this union), and `spoof()` on a
stacked `Raw` now succeeds while leaving the nested store un-spoofed instead of failing.

### Verification

Both round-trip tests fail with the old annotation and pass with the new; the completeness test
fails with `model_rebuild()` removed. Checked against the real path too — `model_dump_json` → an
actual `config.json` → `get_blockwise_tasks_type().validate_python`.

Local `193 passed` vs `190` on base, identical failure sets. **CI is red here and was red on
`will/rbws-plus-main` first**: `ty` gives 42 diagnostics on both, and `Test` fails the same four
`init_block_array` tests on both — verified by running them against each revision.
