### PR TITLE
Skip blocks mask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     # daisy v2 (Rust rewrite) -- pinned to the git v2.0 branch via
     # [tool.uv.sources] below until 2.0.0 is published to PyPI.
     # "daisy>=2",
-    "daisy @ git+https://github.com/funkelab/daisy@v2.0",
+    "daisy @ git+https://github.com/funkelab/daisy@a16076924499efa72da1c7b4f9e23a5b0f2ff560",
     "funlib.geometry>=0.3",
     "funlib.persistence>=0.7.0",
     "funlib.math",
@@ -79,9 +79,11 @@ indirect = [
 
 [tool.uv.sources]
 # daisy v2.0.0 is not on PyPI yet; install the Rust-backed package from the
-# funkelab/daisy v2.0 branch. The buildable pyproject (maturin) is at the repo
-# ROOT (python-source = daisy-py/python), so NO #subdirectory is needed.
-daisy = { git = "https://github.com/funkelab/daisy", branch = "v2.0" }
+# funkelab/daisy v2.0 branch, pinned at a160769: block_done_mask seeds a
+# caller-provided tracking store, which older daisies refuse at scheduler init.
+# The buildable pyproject (maturin) is at the repo ROOT (python-source =
+# daisy-py/python), so NO #subdirectory is needed.
+daisy = { git = "https://github.com/funkelab/daisy", rev = "a16076924499efa72da1c7b4f9e23a5b0f2ff560" }
 
 [project.scripts]
 volara-cli = "volara.cli:cli"

--- a/tests/test_block_done_mask.py
+++ b/tests/test_block_done_mask.py
@@ -1,0 +1,180 @@
+from contextlib import contextmanager
+from typing import Literal
+
+import daisy
+import numpy as np
+import pytest
+import zarr
+from funlib.geometry import Coordinate, Roi
+
+from volara.blockwise.blockwise import _SEED_ATTR, BlockwiseTask
+from volara.datasets import MaskDataset
+from volara.logging import set_log_basedir
+
+
+class MaskableTask(BlockwiseTask):
+    """Minimal concrete task over a 4x1 block grid; the body touches one file
+    per call under ``count_dir`` (daisy may run the body in worker processes,
+    so an in-process list would count nothing)."""
+
+    task_type: Literal["maskable"] = "maskable"
+    label: str = "maskable-task"
+    count_dir: str = ""
+
+    fit: Literal["shrink"] = "shrink"
+    read_write_conflict: Literal[False] = False
+
+    @property
+    def task_name(self) -> str:
+        return self.label
+
+    @property
+    def write_roi(self) -> Roi:
+        return Roi((0, 0), (40, 10))
+
+    @property
+    def write_size(self) -> Coordinate:
+        return Coordinate(10, 10)
+
+    @property
+    def context_size(self) -> Coordinate:
+        return Coordinate(0, 0)
+
+    def drop_artifacts(self):
+        pass
+
+    def init(self):
+        pass
+
+    @contextmanager
+    def process_block_func(self):
+        count_dir = self.count_dir
+
+        def process_block(block):
+            from pathlib import Path as _P
+
+            name = "_".join(str(int(o)) for o in block.write_roi.offset)
+            (_P(count_dir) / name).touch()
+
+        yield process_block
+
+
+def _counted(cls, tmp_path, **kw):
+    d = tmp_path / "calls"
+    d.mkdir(exist_ok=True)
+    return cls(count_dir=str(d), **kw)
+
+
+def _mask(tmp_path, bits, name="mask.zarr"):
+    arr = np.asarray(bits, dtype=np.uint8)
+    z = zarr.open(
+        str(tmp_path / name), mode="w", shape=arr.shape, chunks=arr.shape,
+        dtype="uint8",
+    )
+    z[:] = arr
+    return MaskDataset(store=tmp_path / name)
+
+
+def _calls(task) -> list[str]:
+    from pathlib import Path as _P
+
+    return sorted(p.name for p in _P(task.count_dir).iterdir())
+
+
+def _run(task) -> int:
+    from pathlib import Path as _P
+
+    d = _P(task.count_dir)
+    for f in d.iterdir():
+        f.unlink()
+    with task.task(multiprocessing=False) as t:
+        daisy.run_blockwise([t], progress=False)
+    return len(_calls(task))
+
+
+def test_fresh_seed_runs_exactly_the_unmasked_blocks(tmp_path):
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[1], [0], [1], [0]]))
+    assert _run(t) == 2
+    assert _calls(t) == ["10_0", "30_0"]
+    done = zarr.open(str(t.tracking_path / "done"), mode="r")
+    assert np.asarray(done[:]).ravel().tolist() == [1, 1, 1, 1]
+
+
+def test_a_narrower_mask_unskips_what_it_no_longer_covers(tmp_path):
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[1], [1], [0], [0]], "a.zarr"))
+    assert _run(t) == 2  # cells 2, 3 computed for real
+    t2 = _counted(MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[1], [0], [0], [0]], "b.zarr"))
+    assert _run(t2) == 1, "cell 1 was only ever mask-skipped; the narrower mask must re-run it"
+    assert _calls(t2) == ["10_0"]
+
+
+def test_a_daisy_written_store_counts_as_real_completions(tmp_path):
+    set_log_basedir(tmp_path / "logs")
+    assert _run(_counted(MaskableTask, tmp_path)) == 4  # mask-less: daisy writes its own store
+    t = _counted(MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[1], [0], [0], [0]]))
+    assert _run(t) == 0, "every block was really computed; the mask must not erase that"
+
+
+def test_a_wrong_shape_mask_is_refused_in_python_naming_the_grid(tmp_path):
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[1], [0], [1]]))
+    with pytest.raises(ValueError, match=r"block grid \(4, 1\)"):
+        t._seed_block_done_mask()
+
+
+def test_a_layout_change_refuses_to_reuse_the_seeded_store(tmp_path):
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[1], [0], [1], [0]]))
+    assert _run(t) == 2
+
+    class ShiftedTask(MaskableTask):
+        # same grid shape (4, 1), different world placement: the shape check
+        # cannot catch this; only the recorded layout can
+        @property
+        def write_roi(self) -> Roi:
+            return Roi((10, 0), (40, 10))
+
+    t2 = _counted(ShiftedTask, tmp_path, block_done_mask=_mask(tmp_path, [[1], [0], [1], [0]], "c.zarr"))
+    with pytest.raises(RuntimeError, match="different task geometry"):
+        t2._seed_block_done_mask()
+
+
+def test_the_seed_record_is_written_alongside_the_done_array(tmp_path):
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[0], [1], [0], [0]]))
+    t._seed_block_done_mask()
+    group = zarr.open_group(str(t.tracking_path), mode="r")
+    assert np.asarray(group["seed"][:]).ravel().tolist() == [0, 1, 0, 0]
+    record = group.attrs[_SEED_ATTR]
+    assert record["layout"]["grid_shape"] == [4, 1]
+    assert len(record["mask_sha256"]) == 64
+
+
+def test_mask_dataset_survives_the_task_config_round_trip(tmp_path):
+    t = MaskableTask(block_done_mask=MaskDataset(store=tmp_path / "m.zarr"))
+    round_tripped = MaskableTask.model_validate_json(t.model_dump_json())
+    assert round_tripped.block_done_mask is not None
+    assert str(round_tripped.block_done_mask.store) == str(tmp_path / "m.zarr")
+
+
+def test_block_grid_slices_anchor_at_the_write_offset():
+    class OffsetContextTask(MaskableTask):
+        @property
+        def write_roi(self) -> Roi:
+            return Roi((100, 0), (40, 10))
+
+        @property
+        def context_size(self) -> Coordinate:
+            return Coordinate(9, 0)
+
+    t = OffsetContextTask()
+    # grown total spans [91, 149) -> ceil(58 / 10) = 6 grid cells in dim 0
+    assert t.block_grid_shape == (6, 1)
+    # cell 0 covers the write window starting at write_roi.offset (100), NOT
+    # at the grown total's offset (91)
+    assert t.block_grid_slices(Roi((100, 0), (10, 10))) == (slice(0, 1), slice(0, 1))
+    assert t.block_grid_slices(Roi((130, 0), (10, 10))) == (slice(3, 4), slice(0, 1))
+    # a roi below the anchor clips to the grid's origin
+    assert t.block_grid_slices(Roi((91, 0), (9, 10))) == (slice(0, 0), slice(0, 1))

--- a/volara/blockwise/blockwise.py
+++ b/volara/blockwise/blockwise.py
@@ -16,6 +16,7 @@ from volara.logging import get_log_basedir, set_log_basedir
 from ..utils import PydanticRoi, StrictBaseModel
 from ..workers import Worker
 from .benchmark import BenchmarkLogger
+from ..datasets import MaskDataset
 
 if TYPE_CHECKING:
     from .pipeline import Pipeline
@@ -67,6 +68,23 @@ class BlockwiseTask(StrictBaseModel, ABC):
     single block legitimately runs long (e.g. the global mutex watershed) must set
     an explicit large value instead (see ``GraphMWS``). When a block exceeds the
     timeout daisy reclaims it and retries under ``max_retries``.
+    """
+
+    block_done_mask: MaskDataset | None = None
+    """
+    An optional per-block SKIP mask (a :class:`~volara.datasets.MaskDataset`): a
+    uint8 zarr array over this task's block grid where 1 = skip the block
+    (pre-mark it done) and 0 = run it. Before the run, volara writes it into
+    daisy's tracking store as a caller-provided ``done`` array, so masked blocks
+    are skipped without ever being scheduled -- daisy still creates and tracks the
+    task and reports the skips in its summary. On a resume the mask is OR'd into
+    the existing done state, so real completions from a prior run are preserved.
+
+    The mask's shape must equal daisy's block-grid shape
+    (``ceil(total_roi.shape / block_size)`` over the context-grown total ROI);
+    daisy validates this on open and rejects a mismatch with a useful error. How
+    the mask is built is left to the caller (e.g. a slabreg helper that marks the
+    blocks far from a predicted surface).
     """
 
     def __hash__(self):
@@ -308,6 +326,9 @@ class BlockwiseTask(StrictBaseModel, ABC):
                     with benchmark_logger.trace("Process Block"):
                         process_block(block)
 
+            if self.block_done_mask is not None:
+                self._seed_block_done_mask()
+
             task = daisy.Task(
                 self.task_name,
                 total_roi=self.write_roi.grow(context_low, context_high),
@@ -332,6 +353,45 @@ class BlockwiseTask(StrictBaseModel, ABC):
             )
 
             yield task
+
+    def _seed_block_done_mask(self) -> None:
+        """Write ``block_done_mask`` into daisy's tracking store as a
+        caller-provided ``done`` array, before the task runs.
+
+        daisy accepts a hash-less tracking group and validates it by shape,
+        reading ``done`` as a raw uint8 single-chunk array -- so the mask is
+        written uncompressed at ``chunks == shape``; a compressed chunk would be
+        mmapped as garbage. On a resume the mask is OR'd into whatever daisy
+        already marked done, so real completions from a prior run are preserved.
+        A shape that does not match daisy's block grid is rejected by daisy on
+        open with an actionable error.
+        """
+        import zarr
+
+        skip = (self.block_done_mask.read_mask() != 0).astype(np.uint8)
+        tracking = self.meta_dir / "blocks_done"
+        if (tracking / "done" / "zarr.json").exists():
+            done = zarr.open(str(tracking / "done"), mode="r+")
+            cur = np.asarray(done[:], dtype=np.uint8)
+            if cur.shape != skip.shape:
+                raise ValueError(
+                    f"block_done_mask shape {skip.shape} does not match the "
+                    f"existing done array shape {cur.shape} for task "
+                    f"{self.task_name!r}"
+                )
+            done[:] = cur | skip
+        else:
+            group = zarr.open_group(str(tracking), mode="a")
+            done = group.create_array(
+                "done",
+                shape=skip.shape,
+                chunks=skip.shape,
+                dtype="uint8",
+                fill_value=0,
+                compressors=[],
+                overwrite=True,
+            )
+            done[:] = skip
 
     def get_benchmark_logger(self) -> BenchmarkLogger:
         _benchmark_db_path = Path("volara_benchmark_logs/benchmark.db")

--- a/volara/blockwise/blockwise.py
+++ b/volara/blockwise/blockwise.py
@@ -13,15 +13,78 @@ from funlib.geometry import Coordinate, Roi
 
 from volara.logging import get_log_basedir, set_log_basedir
 
+from ..datasets import MaskDataset
 from ..utils import PydanticRoi, StrictBaseModel
 from ..workers import Worker
 from .benchmark import BenchmarkLogger
-from ..datasets import MaskDataset
 
 if TYPE_CHECKING:
     from .pipeline import Pipeline
 
 logger = logging.getLogger(__name__)
+
+#: Group attribute recording what a seeded tracking store was written for.
+_SEED_ATTR = "volara_block_done_seed"
+
+#: Memoised result of the seeded-store capability probe (None = not yet run).
+_daisy_seeded_store_ok: bool | None = None
+
+
+def _require_daisy_accepts_seeded_store() -> None:
+    """Refuse ``block_done_mask`` on a daisy that rejects caller-seeded stores.
+
+    Measured, not inferred from a version: the probe seeds a one-cell tracking
+    store in exactly the format ``_seed_block_done_mask`` writes and runs a
+    one-block no-op task against it -- the same call path a real seeded run
+    takes. daisy before ``a160769`` refuses such a store at scheduler init
+    (``LayoutMismatch``: no ``daisy_task_hash``); from ``a160769`` it is
+    accepted and validated by shape. The result is memoised per process.
+    """
+    global _daisy_seeded_store_ok
+    if _daisy_seeded_store_ok is None:
+        import tempfile
+
+        import zarr
+
+        with tempfile.TemporaryDirectory(prefix="volara-seed-probe-") as td:
+            tracking = Path(td) / "blocks_done"
+            group = zarr.open_group(str(tracking), mode="a")
+            for name in ("done", "seed"):
+                arr = group.create_array(
+                    name, shape=(1,), chunks=(1,), dtype="uint8",
+                    fill_value=0, compressors=[], overwrite=True,
+                )
+                arr[:] = np.ones(1, dtype=np.uint8)
+            group.attrs[_SEED_ATTR] = {"probe": True}
+            probe = daisy.Task(
+                "volara-block-done-mask-probe",
+                total_roi=Roi((0,), (8,)),
+                read_roi=Roi((0,), (8,)),
+                write_roi=Roi((0,), (8,)),
+                process_function=lambda block: None,
+                fit="shrink",
+                max_workers=1,
+                tracking_path=str(tracking),
+                max_retries=0,
+            )
+            try:
+                daisy.run_blockwise([probe], progress=False)
+                _daisy_seeded_store_ok = True
+            except RuntimeError as e:
+                text = str(e)
+                if "task layout" in text or "daisy_task_hash" in text:
+                    _daisy_seeded_store_ok = False
+                else:
+                    raise
+    if not _daisy_seeded_store_ok:
+        raise RuntimeError(
+            "block_done_mask needs a daisy that accepts a caller-seeded "
+            "(hash-less) tracking store: funkelab/daisy a160769 "
+            "('block_tracking: accept a caller-provided tracking store', "
+            "v2.0 branch, 2026-08-31) or later. The installed daisy refused "
+            "the probe store at scheduler init -- bump the daisy pin and "
+            "relock before using block_done_mask."
+        )
 
 
 class BlockwiseTask(StrictBaseModel, ABC):
@@ -74,17 +137,26 @@ class BlockwiseTask(StrictBaseModel, ABC):
     """
     An optional per-block SKIP mask (a :class:`~volara.datasets.MaskDataset`): a
     uint8 zarr array over this task's block grid where 1 = skip the block
-    (pre-mark it done) and 0 = run it. Before the run, volara writes it into
-    daisy's tracking store as a caller-provided ``done`` array, so masked blocks
-    are skipped without ever being scheduled -- daisy still creates and tracks the
-    task and reports the skips in its summary. On a resume the mask is OR'd into
-    the existing done state, so real completions from a prior run are preserved.
+    (pre-mark it done) and 0 = run it. Before the run, volara seeds it into
+    daisy's tracking store, so masked blocks are skipped without ever being
+    scheduled; daisy still tracks the task and reports the skips in its summary.
 
-    The mask's shape must equal daisy's block-grid shape
-    (``ceil(total_roi.shape / block_size)`` over the context-grown total ROI);
-    daisy validates this on open and rejects a mismatch with a useful error. How
-    the mask is built is left to the caller (e.g. a slabreg helper that marks the
-    blocks far from a predicted surface).
+    Grid contract: the mask's shape must equal :attr:`block_grid_shape`
+    (``ceil(total_roi.shape / block)`` over the context-grown total ROI), and
+    cell ``i`` in dim ``d`` covers the write window starting at
+    ``write_roi.offset[d] + i * block[d]`` -- daisy anchors the grid at the first
+    block's WRITE offset, not at the grown total's offset, and cells beyond
+    ``ceil(write_roi.shape / block)`` are never scheduled. Use
+    :meth:`block_grid_slices` to map a world ROI to cells.
+
+    Resume contract: seeded skip bits are recorded separately from real
+    completions, so re-running with a different mask un-skips blocks the new
+    mask no longer covers while keeping every block a prior run actually
+    computed. A task whose geometry changed refuses to reuse the store.
+
+    Requires a daisy that accepts a caller-seeded tracking store
+    (funkelab/daisy ``a160769``, v2.0 branch, 2026-08-31); on an older daisy the
+    seed refuses up front, naming that commit.
     """
 
     def __hash__(self):
@@ -172,18 +244,55 @@ class BlockwiseTask(StrictBaseModel, ABC):
         """
         return self.meta_dir / "config.json"
 
-
     @property
     def tracking_path(self) -> "Path":
-        """Where daisy persists its built-in per-block tracking for this task.
+        """Where daisy persists its per-block tracking for this task.
 
-        Kept under ``meta_dir`` so ``drop()`` resets it with the logs; MUST agree
-        with the ``tracking_path=`` handed to ``daisy.Task`` in ``task()`` below.
-        (Restored 2026-08-24: this property was on the daisy-tracking branch and
-        was lost when the branch history was rewritten -- callers like
-        fullres_surface_skip read it to pre-mark skippable blocks.)
+        Kept under ``meta_dir`` so ``drop()`` resets it with the logs; ``task()``
+        hands exactly this path to ``daisy.Task(tracking_path=...)``.
         """
         return self.meta_dir / "blocks_done"
+
+    def _context_pair(self) -> tuple[Coordinate, Coordinate]:
+        """``(context_low, context_high)`` as ``task()`` resolves them."""
+        context = self.context_size
+        if not isinstance(context, Coordinate):
+            assert isinstance(context, tuple)
+            return context[0], context[1]
+        return context, context
+
+    @property
+    def block_grid_shape(self) -> tuple[int, ...]:
+        """Shape of daisy's per-block tracking grid for this task.
+
+        ``ceil(total_roi.shape / block)`` where ``total_roi`` is the
+        context-grown write ROI and ``block`` is ``block_write_roi.shape`` --
+        the same numbers ``task()`` hands to ``daisy.Task``.
+        """
+        lo, hi = self._context_pair()
+        total = self.write_roi.grow(lo, hi)
+        block = self.block_write_roi.shape
+        return tuple(-(-int(t) // int(b)) for t, b in zip(total.shape, block))
+
+    def block_grid_slices(self, roi: Roi) -> tuple[slice, ...]:
+        """Grid cells whose WRITE window intersects ``roi``, as per-dim slices.
+
+        Cell ``i`` in dim ``d`` covers the write window starting at
+        ``write_roi.offset[d] + i * block[d]``: daisy anchors the grid at the
+        first block's write offset, not at the context-grown total's offset.
+        Slices are clipped to :attr:`block_grid_shape`.
+        """
+        block = self.block_write_roi.shape
+        anchor = self.write_roi.offset
+        grid = self.block_grid_shape
+        out = []
+        for d, (a, b, g) in enumerate(zip(anchor, block, grid)):
+            begin = int(roi.begin[d]) - int(a)
+            end = int(roi.end[d]) - int(a)
+            lo = max(begin // int(b), 0)
+            hi = min(-(-end // int(b)), g)
+            out.append(slice(lo, max(hi, lo)))
+        return tuple(out)
 
     def process_roi(self, roi: Roi, context: Coordinate | None = None):
         """
@@ -338,7 +447,7 @@ class BlockwiseTask(StrictBaseModel, ABC):
                 read_write_conflict=self.read_write_conflict,
                 fit=self.fit,
                 max_workers=self.num_workers,
-                tracking_path=str(self.meta_dir / "blocks_done"),
+                tracking_path=str(self.tracking_path),
                 max_retries=2,
                 timeout=self.block_timeout,
                 upstream_tasks=(
@@ -354,44 +463,99 @@ class BlockwiseTask(StrictBaseModel, ABC):
 
             yield task
 
-    def _seed_block_done_mask(self) -> None:
-        """Write ``block_done_mask`` into daisy's tracking store as a
-        caller-provided ``done`` array, before the task runs.
+    def _seed_layout(self) -> dict:
+        """The task geometry a seeded tracking store is only valid for."""
+        lo, hi = self._context_pair()
+        total = self.write_roi.grow(lo, hi)
+        return {
+            "total_roi": [list(total.offset), list(total.shape)],
+            "read_roi": [
+                list(self.block_write_roi.grow(lo, hi).offset),
+                list(self.block_write_roi.grow(lo, hi).shape),
+            ],
+            "write_roi": [
+                list(self.block_write_roi.offset),
+                list(self.block_write_roi.shape),
+            ],
+            "fit": str(self.fit),
+            "grid_shape": list(self.block_grid_shape),
+        }
 
-        daisy accepts a hash-less tracking group and validates it by shape,
-        reading ``done`` as a raw uint8 single-chunk array -- so the mask is
-        written uncompressed at ``chunks == shape``; a compressed chunk would be
-        mmapped as garbage. On a resume the mask is OR'd into whatever daisy
-        already marked done, so real completions from a prior run are preserved.
-        A shape that does not match daisy's block grid is rejected by daisy on
-        open with an actionable error.
+    def _seed_block_done_mask(self) -> None:
+        """Seed ``block_done_mask`` into daisy's tracking store before the run.
+
+        The mask is written uncompressed at ``chunks == shape`` (daisy reads
+        ``done`` as a raw single-chunk uint8 array). The seeded skip bits are
+        ALSO recorded in a sibling ``seed`` array plus a layout stamp in the
+        group attributes, so on a resume real completions are
+        ``done & ~previous_seed`` and the new mask replaces the old: a narrower
+        mask un-skips what it no longer covers, and completed work is never
+        re-marked. A store whose recorded layout differs from this task's
+        geometry refuses (drop the meta dir to reset tracking). A daisy-written
+        store from a mask-less run is treated as all real completions.
         """
+        import hashlib
+
         import zarr
 
+        _require_daisy_accepts_seeded_store()
         skip = (self.block_done_mask.read_mask() != 0).astype(np.uint8)
-        tracking = self.meta_dir / "blocks_done"
+        expected = self.block_grid_shape
+        if tuple(skip.shape) != tuple(expected):
+            raise ValueError(
+                f"block_done_mask shape {tuple(skip.shape)} does not match task "
+                f"{self.task_name!r}'s block grid {tuple(expected)} "
+                "(= ceil(context-grown total / block); cell i covers the write "
+                "window at write_roi.offset + i*block -- see block_grid_slices())."
+            )
+        layout = self._seed_layout()
+        record = {
+            "layout": layout,
+            "mask_sha256": hashlib.sha256(skip.tobytes()).hexdigest(),
+        }
+        tracking = self.tracking_path
         if (tracking / "done" / "zarr.json").exists():
-            done = zarr.open(str(tracking / "done"), mode="r+")
+            group = zarr.open_group(str(tracking), mode="r+")
+            done = group["done"]
             cur = np.asarray(done[:], dtype=np.uint8)
             if cur.shape != skip.shape:
                 raise ValueError(
-                    f"block_done_mask shape {skip.shape} does not match the "
-                    f"existing done array shape {cur.shape} for task "
-                    f"{self.task_name!r}"
+                    f"block_done_mask shape {tuple(skip.shape)} does not match "
+                    f"the existing done array shape {cur.shape} for task "
+                    f"{self.task_name!r}; drop the meta dir to reset tracking."
                 )
-            done[:] = cur | skip
+            prior = group.attrs.get(_SEED_ATTR)
+            if prior is not None:
+                if prior.get("layout") != layout:
+                    raise RuntimeError(
+                        f"task {self.task_name!r}: the seeded tracking store at "
+                        f"{tracking} was written for a different task geometry; "
+                        f"drop the meta dir ({self.meta_dir}) to reset tracking "
+                        "rather than reusing done bits from another layout."
+                    )
+                prev_seed = np.asarray(group["seed"][:], dtype=np.uint8)
+                real = cur & ~prev_seed
+            else:
+                real = cur
+            done[:] = real | skip
+            if "seed" in group:
+                group["seed"][:] = skip
+            else:
+                seed = group.create_array(
+                    "seed", shape=skip.shape, chunks=skip.shape, dtype="uint8",
+                    fill_value=0, compressors=[], overwrite=True,
+                )
+                seed[:] = skip
+            group.attrs[_SEED_ATTR] = record
         else:
             group = zarr.open_group(str(tracking), mode="a")
-            done = group.create_array(
-                "done",
-                shape=skip.shape,
-                chunks=skip.shape,
-                dtype="uint8",
-                fill_value=0,
-                compressors=[],
-                overwrite=True,
-            )
-            done[:] = skip
+            for name in ("done", "seed"):
+                arr = group.create_array(
+                    name, shape=skip.shape, chunks=skip.shape, dtype="uint8",
+                    fill_value=0, compressors=[], overwrite=True,
+                )
+                arr[:] = skip
+            group.attrs[_SEED_ATTR] = record
 
     def get_benchmark_logger(self) -> BenchmarkLogger:
         _benchmark_db_path = Path("volara_benchmark_logs/benchmark.db")

--- a/volara/blockwise/blockwise.py
+++ b/volara/blockwise/blockwise.py
@@ -155,6 +155,18 @@ class BlockwiseTask(StrictBaseModel, ABC):
         return self.meta_dir / "config.json"
 
 
+    @property
+    def tracking_path(self) -> "Path":
+        """Where daisy persists its built-in per-block tracking for this task.
+
+        Kept under ``meta_dir`` so ``drop()`` resets it with the logs; MUST agree
+        with the ``tracking_path=`` handed to ``daisy.Task`` in ``task()`` below.
+        (Restored 2026-08-24: this property was on the daisy-tracking branch and
+        was lost when the branch history was rewritten -- callers like
+        fullres_surface_skip read it to pre-mark skippable blocks.)
+        """
+        return self.meta_dir / "blocks_done"
+
     def process_roi(self, roi: Roi, context: Coordinate | None = None):
         """
         A helper function to process a given roi without needing to start a

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -404,20 +404,17 @@ class MaskDataset(Dataset):
     """A per-block SKIP mask for a blockwise task.
 
     Points to a zarr array in the task's BLOCK-GRID space -- one element per
-    *block*, not per voxel: dtype uint8, shape equal to daisy's block-grid shape
-    (``ceil(total_roi.shape / block_size)`` over the context-grown total ROI),
-    value 1 = skip this block (pre-mark it done), 0 = run it.
+    *block*, not per voxel: dtype uint8, shape equal to the task's
+    ``block_grid_shape`` (``ceil(total_roi.shape / block)`` over the
+    context-grown total ROI), value 1 = skip this block (pre-mark it done),
+    0 = run it. Cell ``i`` in dim ``d`` covers the write window starting at
+    ``write_roi.offset[d] + i * block[d]``; build masks with
+    ``BlockwiseTask.block_grid_slices``.
 
-    Handed to ``BlockwiseTask.block_done_mask``, volara writes it into daisy's
-    tracking store as a *caller-provided* ``done`` array (daisy accepts a
-    hash-less tracking group and validates it by shape), so the masked blocks
-    are skipped without ever running. This is the generic form of the
-    surface-band skip: a thin predicted surface only touches a few blocks, so the
-    rest can be pre-skipped.
+    Handed to ``BlockwiseTask.block_done_mask``, volara seeds it into daisy's
+    tracking store so the masked blocks are skipped without ever running.
 
     Grid-space, not voxel-space: the inherited voxel-metadata fields are unused.
-    How the mask is built is left to the caller (e.g. a slabreg helper that marks
-    the blocks whose Z range cannot reach a predicted surface).
     """
 
     dataset_type: Literal["mask"] = "mask"

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -400,6 +400,39 @@ class Labels(Dataset):
         return {}
 
 
+class MaskDataset(Dataset):
+    """A per-block SKIP mask for a blockwise task.
+
+    Points to a zarr array in the task's BLOCK-GRID space -- one element per
+    *block*, not per voxel: dtype uint8, shape equal to daisy's block-grid shape
+    (``ceil(total_roi.shape / block_size)`` over the context-grown total ROI),
+    value 1 = skip this block (pre-mark it done), 0 = run it.
+
+    Handed to ``BlockwiseTask.block_done_mask``, volara writes it into daisy's
+    tracking store as a *caller-provided* ``done`` array (daisy accepts a
+    hash-less tracking group and validates it by shape), so the masked blocks
+    are skipped without ever running. This is the generic form of the
+    surface-band skip: a thin predicted surface only touches a few blocks, so the
+    rest can be pre-skipped.
+
+    Grid-space, not voxel-space: the inherited voxel-metadata fields are unused.
+    How the mask is built is left to the caller (e.g. a slabreg helper that marks
+    the blocks whose Z range cannot reach a predicted surface).
+    """
+
+    dataset_type: Literal["mask"] = "mask"
+
+    @property
+    def attrs(self):
+        return {}
+
+    def read_mask(self) -> "np.ndarray":
+        """The mask as a uint8 numpy array in block-grid space (1 = skip)."""
+        import zarr
+
+        return np.asarray(zarr.open(str(self.store), mode="r")[:], dtype=np.uint8)
+
+
 class CloudVolumeWrapper(Dataset):
     """
     Represents a volumetric dataset through Cloud Volume.


### PR DESCRIPTION
Add support for pre marking blocks as done.

This is done by pre-filling the block_done array with a mask. Note 1 means the block is done and does not get computed.
This needs a bit of cleanup. There is 1 unrelated change in here, and the MaskDataset is not needed, it should just be a LabelDataset.