### PR TITLE
block_done_mask: skip pre-marked blocks via a caller-provided MaskDataset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     # daisy v2 (Rust rewrite) -- pinned to the git v2.0 branch via
     # [tool.uv.sources] below until 2.0.0 is published to PyPI.
     # "daisy>=2",
-    "daisy @ git+https://github.com/funkelab/daisy@v2.0",
+    "daisy @ git+https://github.com/funkelab/daisy@a16076924499efa72da1c7b4f9e23a5b0f2ff560",
     "funlib.geometry>=0.3",
     "funlib.persistence>=0.7.0",
     "funlib.math",
@@ -79,9 +79,11 @@ indirect = [
 
 [tool.uv.sources]
 # daisy v2.0.0 is not on PyPI yet; install the Rust-backed package from the
-# funkelab/daisy v2.0 branch. The buildable pyproject (maturin) is at the repo
-# ROOT (python-source = daisy-py/python), so NO #subdirectory is needed.
-daisy = { git = "https://github.com/funkelab/daisy", branch = "v2.0" }
+# funkelab/daisy v2.0 branch, pinned at a160769: block_done_mask seeds a
+# caller-provided tracking store, which older daisies refuse at scheduler init.
+# The buildable pyproject (maturin) is at the repo ROOT (python-source =
+# daisy-py/python), so NO #subdirectory is needed.
+daisy = { git = "https://github.com/funkelab/daisy", rev = "a16076924499efa72da1c7b4f9e23a5b0f2ff560" }
 
 [project.scripts]
 volara-cli = "volara.cli:cli"

--- a/tests/test_block_done_mask.py
+++ b/tests/test_block_done_mask.py
@@ -1,0 +1,464 @@
+from contextlib import contextmanager
+from typing import Literal
+
+import daisy
+import numpy as np
+import pytest
+import zarr
+from funlib.geometry import Coordinate, Roi
+
+from volara.blockwise.blockwise import _SEED_ATTR, BlockwiseTask
+from volara.datasets import MaskDataset
+from volara.logging import set_log_basedir
+
+
+class MaskableTask(BlockwiseTask):
+    """Minimal concrete task over a 4x1 block grid; the body touches one file
+    per call under ``count_dir`` (daisy may run the body in worker processes,
+    so an in-process list would count nothing)."""
+
+    task_type: Literal["maskable"] = "maskable"
+    label: str = "maskable-task"
+    count_dir: str = ""
+
+    fit: Literal["shrink"] = "shrink"
+    read_write_conflict: Literal[False] = False
+
+    @property
+    def task_name(self) -> str:
+        return self.label
+
+    @property
+    def write_roi(self) -> Roi:
+        return Roi((0, 0), (40, 10))
+
+    @property
+    def write_size(self) -> Coordinate:
+        return Coordinate(10, 10)
+
+    @property
+    def context_size(self) -> Coordinate:
+        return Coordinate(0, 0)
+
+    def drop_artifacts(self):
+        pass
+
+    def init(self):
+        pass
+
+    @contextmanager
+    def process_block_func(self):
+        count_dir = self.count_dir
+
+        def process_block(block):
+            from pathlib import Path as _P
+
+            name = "_".join(str(int(o)) for o in block.write_roi.offset)
+            (_P(count_dir) / name).touch()
+
+        yield process_block
+
+
+def _counted(cls, tmp_path, **kw):
+    d = tmp_path / "calls"
+    d.mkdir(exist_ok=True)
+    return cls(count_dir=str(d), **kw)
+
+
+def _mask(tmp_path, bits, name="mask.zarr"):
+    arr = np.asarray(bits, dtype=np.uint8)
+    z = zarr.open(
+        str(tmp_path / name),
+        mode="w",
+        shape=arr.shape,
+        chunks=arr.shape,
+        dtype="uint8",
+    )
+    z[:] = arr
+    return MaskDataset(store=tmp_path / name)
+
+
+def _calls(task) -> list[str]:
+    from pathlib import Path as _P
+
+    return sorted(p.name for p in _P(task.count_dir).iterdir())
+
+
+def _run(task) -> int:
+    from pathlib import Path as _P
+
+    d = _P(task.count_dir)
+    for f in d.iterdir():
+        f.unlink()
+    with task.task(multiprocessing=False) as t:
+        daisy.run_blockwise([t], progress=False)
+    return len(_calls(task))
+
+
+def test_fresh_seed_runs_exactly_the_unmasked_blocks(tmp_path):
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(
+        MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[1], [0], [1], [0]])
+    )
+    assert _run(t) == 2
+    assert _calls(t) == ["10_0", "30_0"]
+    done = zarr.open(str(t.tracking_path / "done"), mode="r")
+    assert np.asarray(done[:]).ravel().tolist() == [1, 1, 1, 1]
+
+
+def test_a_narrower_mask_unskips_what_it_no_longer_covers(tmp_path):
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(
+        MaskableTask,
+        tmp_path,
+        block_done_mask=_mask(tmp_path, [[1], [1], [0], [0]], "a.zarr"),
+    )
+    assert _run(t) == 2  # cells 2, 3 computed for real
+    t2 = _counted(
+        MaskableTask,
+        tmp_path,
+        block_done_mask=_mask(tmp_path, [[1], [0], [0], [0]], "b.zarr"),
+    )
+    assert _run(t2) == 1, (
+        "cell 1 was only ever mask-skipped; the narrower mask must re-run it"
+    )
+    assert _calls(t2) == ["10_0"]
+
+
+def test_a_daisy_written_store_counts_as_real_completions(tmp_path):
+    """A STRICT SUBSET must complete first: with all four done, `_run == 0` holds
+    even under the bug where a mask erases real completions, so the assertion
+    could not fail on what its name claims."""
+    set_log_basedir(tmp_path / "logs")
+    # Mask cells 0 and 1 so only 2 and 3 are ever really computed by daisy...
+    t = _counted(
+        MaskableTask,
+        tmp_path,
+        block_done_mask=_mask(tmp_path, [[1], [1], [0], [0]], "sub.zarr"),
+    )
+    assert _run(t) == 2 and _calls(t) == ["20_0", "30_0"]
+    # ...then drop to a mask that covers neither: 0 and 1 were only mask-skipped
+    # and must re-run, while 2 and 3 were earned and must not.
+    t2 = _counted(
+        MaskableTask,
+        tmp_path,
+        block_done_mask=_mask(tmp_path, [[0], [0], [0], [0]], "none.zarr"),
+    )
+    assert _run(t2) == 2, "the two mask-only cells re-run; the two real ones do not"
+    assert _calls(t2) == ["0_0", "10_0"]
+
+
+def test_a_wrong_shape_mask_is_refused_in_python_naming_the_grid(tmp_path):
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(
+        MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[1], [0], [1]])
+    )
+    with pytest.raises(ValueError, match=r"block grid \(4, 1\)"):
+        t._seed_block_done_mask()
+
+
+def test_a_layout_change_refuses_to_reuse_the_seeded_store(tmp_path):
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(
+        MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[1], [0], [1], [0]])
+    )
+    assert _run(t) == 2
+
+    class ShiftedTask(MaskableTask):
+        # same grid shape (4, 1), different world placement: the shape check
+        # cannot catch this; only the recorded layout can
+        @property
+        def write_roi(self) -> Roi:
+            return Roi((10, 0), (40, 10))
+
+    t2 = _counted(
+        ShiftedTask,
+        tmp_path,
+        block_done_mask=_mask(tmp_path, [[1], [0], [1], [0]], "c.zarr"),
+    )
+    with pytest.raises(RuntimeError, match="different task geometry"):
+        t2._seed_block_done_mask()
+
+
+def test_the_seed_record_is_written_alongside_the_done_array(tmp_path):
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(
+        MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[0], [1], [0], [0]])
+    )
+    t._seed_block_done_mask()
+    group = zarr.open_group(str(t.tracking_path), mode="r")
+    assert np.asarray(group["seed"][:]).ravel().tolist() == [0, 1, 0, 0]
+    record = group.attrs[_SEED_ATTR]
+    assert record["layout"]["grid_shape"] == [4, 1]
+    # `len(...) == 64` holds for ANY hexdigest; pin the digest of THIS mask, so a
+    # record that describes a different mask fails.
+    import hashlib
+
+    expected = hashlib.sha256(
+        np.asarray([[0], [1], [0], [0]], dtype=np.uint8).tobytes()
+    )
+    assert record["mask_sha256"] == expected.hexdigest()
+
+
+def test_mask_dataset_survives_the_task_config_round_trip(tmp_path):
+    t = MaskableTask(block_done_mask=MaskDataset(store=tmp_path / "m.zarr"))
+    round_tripped = MaskableTask.model_validate_json(t.model_dump_json())
+    assert round_tripped.block_done_mask is not None
+    # Comparing str(...) to str(...) passes whatever the type became; compare the
+    # value the way a consumer uses it, and pin the type separately.
+    got = round_tripped.block_done_mask.store
+    assert got == t.block_done_mask.store
+    assert isinstance(got, type(t.block_done_mask.store))
+
+
+def test_block_grid_slices_anchor_below_the_write_offset_when_context_exceeds_a_block():
+    """⛔ The old version of this test used ``context=9 < block=10``, where the
+    buggy and correct anchors coincide -- it passed on the bug and enshrined the
+    wrong contract. Both regimes are pinned here, and
+    ``test_the_grid_anchor_matches_daisys_own_done_array`` checks the answer
+    against daisy instead of against our own formula."""
+
+    class NoContext(MaskableTask):
+        @property
+        def write_roi(self) -> Roi:
+            return Roi((100, 0), (40, 10))
+
+        @property
+        def context_size(self) -> Coordinate:
+            return Coordinate(9, 0)
+
+    t = NoContext()
+    # grown total spans [91, 149) -> ceil(58 / 10) = 6 cells in dim 0, and
+    # 9 // 10 == 0, so cell 0 still starts at the write offset.
+    assert t.block_grid_shape == (6, 1)
+    assert t.block_grid_cell_origin() == Coordinate(100, 0)
+    assert t.block_grid_slices(Roi((100, 0), (10, 10))) == (slice(0, 1), slice(0, 1))
+    assert t.block_grid_slices(Roi((130, 0), (10, 10))) == (slice(3, 4), slice(0, 1))
+    assert t.block_grid_slices(Roi((91, 0), (9, 10))) == (slice(0, 0), slice(0, 1))
+
+    class ContextExceedsBlock(MaskableTask):
+        @property
+        def write_roi(self) -> Roi:
+            return Roi((100, 0), (40, 10))
+
+        @property
+        def context_size(self) -> Coordinate:
+            return Coordinate(25, 0)
+
+    t2 = ContextExceedsBlock()
+    # grown total spans [75, 165) -> 9 cells; 25 // 10 == 2, so the block written
+    # at 100 is cell 2 and the grid's cell 0 starts at 80.
+    assert t2.block_grid_shape == (9, 1)
+    assert t2.block_grid_cell_origin() == Coordinate(80, 0)
+    assert t2.block_grid_slices(Roi((100, 0), (10, 10))) == (slice(2, 3), slice(0, 1))
+    assert t2.block_grid_slices(Roi((130, 0), (10, 10))) == (slice(5, 6), slice(0, 1))
+
+
+def test_the_grid_anchor_matches_daisys_own_done_array(tmp_path):
+    """⛔ The property B2 was about, checked against daisy rather than restated.
+
+    daisy indexes a block as ``(write_roi.offset - total_roi.offset) //
+    write_shape`` and volara hands it the CONTEXT-GROWN write ROI, so the cell a
+    block lands in shifts by ``context_low // block``. Run a real mask-less task
+    and require that every cell daisy marks is one ``block_grid_slices`` predicts
+    for that block -- a formula-vs-formula test cannot see this.
+    """
+    set_log_basedir(tmp_path / "logs")
+
+    class ContextExceedsBlock(MaskableTask):
+        @property
+        def context_size(self) -> Coordinate:
+            return Coordinate(25, 0)
+
+    t = _counted(ContextExceedsBlock, tmp_path)
+    assert _run(t) == 4
+    done = np.asarray(zarr.open(str(t.tracking_path / "done"), mode="r")[:]).ravel()
+
+    predicted = np.zeros_like(done)
+    for name in _calls(t):
+        off = Coordinate(int(x) for x in name.split("_"))
+        sl = t.block_grid_slices(Roi(off, t.write_size))
+        predicted[sl[0]] = 1
+    assert predicted.tolist() == done.tolist(), (
+        f"block_grid_slices predicts {predicted.tolist()} but daisy marked "
+        f"{done.tolist()} -- the grid anchor disagrees with daisy"
+    )
+    # And the shift is real, not a no-op: 25 // 10 == 2 cells.
+    assert done.tolist() == [0, 0, 1, 1, 1, 1, 0, 0, 0]
+
+
+def test_dropping_the_mask_unskips_what_it_had_seeded(tmp_path):
+    """⛔ B1. Seeding only when a mask is present leaves the last run's skip bits
+    standing, and daisy honours them: the narrowest mask of all -- removing the
+    field -- would be the one case that never un-skips. Measured before the fix:
+    the mask-less rerun logged "resumed -- 1/4 blocks skipped" and left the
+    masked region unwritten with failed=0."""
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(
+        MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[1], [1], [0], [0]])
+    )
+    assert _run(t) == 2 and _calls(t) == ["20_0", "30_0"]
+
+    t2 = _counted(MaskableTask, tmp_path)  # same meta dir, NO mask
+    assert _run(t2) == 2, "the two mask-only cells must run once the mask is gone"
+    assert _calls(t2) == ["0_0", "10_0"]
+
+
+def test_a_store_volara_never_seeded_is_left_alone(tmp_path):
+    """The other half of B1's fix: an unmasked task on an unmasked store must not
+    write anything, must not need a capable daisy, and must resume normally."""
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(MaskableTask, tmp_path)
+    assert _run(t) == 4
+    group = zarr.open_group(str(t.tracking_path), mode="r")
+    assert _SEED_ATTR not in group.attrs and "seed" not in group
+    assert _run(t) == 0, "daisy's own markers still resume"
+
+
+def test_a_layout_change_refuses_even_without_a_mask(tmp_path):
+    """⛔ B3. A store volara seeded never gets daisy's own ``daisy_task_hash``
+    (volara creates the group, and daisy only stamps groups it creates), and a
+    hash-less store is accepted for ANY layout -- so volara's stamp is that
+    store's only layout identity. Checking it only on masked runs leaves the
+    mask-less path free to reuse another geometry's done bits."""
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(
+        MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[1], [0], [1], [0]])
+    )
+    assert _run(t) == 2
+
+    class ShiftedTask(MaskableTask):
+        @property
+        def write_roi(self) -> Roi:
+            return Roi((10, 0), (40, 10))
+
+    t2 = _counted(
+        ShiftedTask, tmp_path
+    )  # same grid shape, different placement, NO mask
+    with pytest.raises(RuntimeError, match="different task geometry"):
+        t2._seed_block_done_mask()
+
+
+def test_widening_then_narrowing_keeps_the_real_completions(tmp_path):
+    """⛔ N1. Recording the whole new mask as seeded overwrites the bits a worker
+    earned, so a later narrowing re-runs completed blocks. Safe in direction,
+    but it can cost a full pass."""
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(
+        MaskableTask,
+        tmp_path,
+        block_done_mask=_mask(tmp_path, [[1], [1], [0], [0]], "w1.zarr"),
+    )
+    assert _run(t) == 2 and _calls(t) == ["20_0", "30_0"]  # 2 and 3 are REAL
+
+    t2 = _counted(
+        MaskableTask,
+        tmp_path,
+        block_done_mask=_mask(tmp_path, [[1], [1], [1], [1]], "w2.zarr"),
+    )
+    assert _run(t2) == 0  # everything masked
+
+    t3 = _counted(
+        MaskableTask,
+        tmp_path,
+        block_done_mask=_mask(tmp_path, [[0], [0], [0], [0]], "w3.zarr"),
+    )
+    assert _run(t3) == 2, "cells 2 and 3 were earned; only the mask-only cells re-run"
+    assert _calls(t3) == ["0_0", "10_0"]
+
+
+def test_an_interrupted_narrowing_never_promotes_a_seed_to_a_completion(
+    tmp_path, monkeypatch
+):
+    """⛔ The resume invariant is ``done & ~seed == real``, and the write ORDER is
+    what preserves it under interruption. Narrowing ``seed`` before ``done``
+    breaks it in exactly the direction this feature exists for: cell 0 is
+    mask-skipped, the mask is then dropped, and a failure anywhere in the window
+    leaves ``done=[1,1,1,1] seed=[0,0,0,0]`` -- cell 0 a permanent completion no
+    worker ever ran, reported with ``failed=0``.
+
+    Each write is interrupted in turn by making it raise, which is what an ENOSPC
+    or a killed driver looks like from the store's side; the next run must still
+    recover cell 0.
+
+    ⚠️ This replaces an ``inspect.getsource`` index comparison that passed on the
+    bug and on the fix alike -- it pinned the source text, not the behaviour.
+    """
+    from volara.blockwise.blockwise import BlockwiseTask
+
+    # On the class a staticmethod is already the plain function.
+    real_write = BlockwiseTask._write_grid_array
+
+    for stop_after in range(3):
+        base = tmp_path / f"crash{stop_after}"
+        base.mkdir()
+        set_log_basedir(base / "logs")
+        t = _counted(
+            MaskableTask, base, block_done_mask=_mask(base, [[1], [0], [0], [0]])
+        )
+        assert _run(t) == 3 and _calls(t) == ["10_0", "20_0", "30_0"]
+
+        done_writes = {"n": 0}
+
+        def flaky(group, name, values, _stop=stop_after, _n=done_writes):
+            if _n["n"] >= _stop:
+                raise OSError(28, "No space left on device")
+            _n["n"] += 1
+            real_write(group, name, values)
+
+        t2 = _counted(MaskableTask, base)  # the mask is DROPPED -- the narrowest of all
+        with monkeypatch.context() as mp:
+            mp.setattr(BlockwiseTask, "_write_grid_array", staticmethod(flaky))
+            with pytest.raises(OSError):
+                t2._seed_block_done_mask()
+
+        t3 = _counted(MaskableTask, base)
+        _run(t3)
+        assert "0_0" in _calls(t3), (
+            f"interrupted after {stop_after} write(s): cell 0 was mask-skipped and "
+            f"never computed, yet the store reports it done"
+        )
+
+
+def test_a_mask_arriving_on_a_daisy_owned_store_keeps_its_completions(tmp_path):
+    """The ``prior is None`` branch -- a store daisy wrote, so every bit in it was
+    earned. Ordering matters: the first run must be UNMASKED, or ``prior`` is set
+    and this exercises ``cur & ~prev_seed`` instead. (An earlier version of this
+    file named this branch in a test that never reached it.)"""
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(MaskableTask, tmp_path)
+    assert _run(t) == 4  # daisy writes its own store
+    group = zarr.open_group(str(t.tracking_path), mode="r")
+    assert _SEED_ATTR not in group.attrs, "precondition: daisy owns this store"
+
+    t2 = _counted(
+        MaskableTask, tmp_path, block_done_mask=_mask(tmp_path, [[1], [0], [0], [0]])
+    )
+    assert _run(t2) == 0, "a mask must not erase completions daisy recorded"
+
+
+def test_a_daisy_owned_store_is_not_bricked_by_a_refused_masked_run(tmp_path):
+    """⛔ Where daisy's own ``daisy_task_hash`` is present, daisy validates the
+    geometry and is the authority; volara's stamp is for the hash-less stores
+    daisy accepts for ANY layout. Honouring our stamp on a daisy-owned store
+    means a masked run at the wrong geometry writes the stamp, daisy refuses and
+    runs nothing, and every later run of the ORIGINAL task refuses on our stale
+    stamp -- a full recompute owed to a mistake that computed nothing."""
+    set_log_basedir(tmp_path / "logs")
+    t = _counted(MaskableTask, tmp_path)
+    assert _run(t) == 4
+
+    class ShiftedTask(MaskableTask):
+        @property
+        def write_roi(self) -> Roi:
+            return Roi((10, 0), (40, 10))
+
+    t2 = _counted(
+        ShiftedTask,
+        tmp_path,
+        block_done_mask=_mask(tmp_path, [[1], [0], [0], [0]], "s.zarr"),
+    )
+    t2._seed_block_done_mask()  # volara must not refuse; daisy owns the layout here
+
+    t3 = _counted(MaskableTask, tmp_path)
+    assert _run(t3) == 0, "the original task must still resume on its own completions"

--- a/volara/blockwise/blockwise.py
+++ b/volara/blockwise/blockwise.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from shutil import rmtree
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Any, Iterator, cast
 
 import daisy
 import numpy as np
@@ -13,15 +13,87 @@ from funlib.geometry import Coordinate, Roi
 
 from volara.logging import get_log_basedir, set_log_basedir
 
+from ..datasets import MaskDataset
 from ..utils import PydanticRoi, StrictBaseModel
 from ..workers import Worker
 from .benchmark import BenchmarkLogger
-from ..datasets import MaskDataset
 
 if TYPE_CHECKING:
     from .pipeline import Pipeline
 
 logger = logging.getLogger(__name__)
+
+#: Group attribute recording what a seeded tracking store was written for.
+_SEED_ATTR = "volara_block_done_seed"
+
+#: Memoised result of the seeded-store capability probe (None = not yet run).
+_daisy_seeded_store_ok: bool | None = None
+
+
+def _require_daisy_accepts_seeded_store() -> None:
+    """Refuse ``block_done_mask`` on a daisy that rejects caller-seeded stores.
+
+    Measured, not inferred from a version: the probe seeds a one-cell tracking
+    store in exactly the format ``_seed_block_done_mask`` writes and runs a
+    one-block no-op task against it -- the same call path a real seeded run
+    takes. daisy before ``a160769`` refuses such a store at scheduler init
+    (``LayoutMismatch``: no ``daisy_task_hash``); from ``a160769`` it is
+    accepted and validated by shape. The result is memoised per process.
+    """
+    global _daisy_seeded_store_ok
+    if _daisy_seeded_store_ok is None:
+        import tempfile
+
+        import zarr
+
+        with tempfile.TemporaryDirectory(prefix="volara-seed-probe-") as td:
+            tracking = Path(td) / "blocks_done"
+            group = zarr.open_group(str(tracking), mode="a")
+            for name in ("done", "seed"):
+                arr = group.create_array(
+                    name, shape=(1,), chunks=(1,), dtype="uint8",
+                    fill_value=0, compressors=[], overwrite=True,
+                )
+                arr[:] = np.ones(1, dtype=np.uint8)
+            group.attrs[_SEED_ATTR] = {"probe": True}
+            probe = daisy.Task(
+                "volara-block-done-mask-probe",
+                total_roi=Roi((0,), (8,)),
+                read_roi=Roi((0,), (8,)),
+                write_roi=Roi((0,), (8,)),
+                process_function=lambda block: None,
+                fit="shrink",
+                max_workers=1,
+                tracking_path=str(tracking),
+                max_retries=0,
+            )
+            try:
+                # ⚠️ multiprocessing=False. The refusal happens at tracking
+                # init, before any server, so both settings return the same
+                # verdict -- but the default stands up the distributed
+                # scheduler, a TCP server and a worker for a no-op block.
+                # Measured: 0.917s -> 0.006s, and it stops the probe printing
+                # an Execution Summary and creating daisy_logs/ in the caller's
+                # cwd on every process that touches a mask.
+                daisy.run_blockwise(
+                    [probe], progress=False, multiprocessing=False
+                )
+                _daisy_seeded_store_ok = True
+            except RuntimeError as e:
+                text = str(e)
+                if "task layout" in text or "daisy_task_hash" in text:
+                    _daisy_seeded_store_ok = False
+                else:
+                    raise
+    if not _daisy_seeded_store_ok:
+        raise RuntimeError(
+            "block_done_mask needs a daisy that accepts a caller-seeded "
+            "(hash-less) tracking store: funkelab/daisy a160769 "
+            "('block_tracking: accept a caller-provided tracking store', "
+            "v2.0 branch, 2026-08-31) or later. The installed daisy refused "
+            "the probe store at scheduler init -- bump the daisy pin and "
+            "relock before using block_done_mask."
+        )
 
 
 class BlockwiseTask(StrictBaseModel, ABC):
@@ -74,17 +146,27 @@ class BlockwiseTask(StrictBaseModel, ABC):
     """
     An optional per-block SKIP mask (a :class:`~volara.datasets.MaskDataset`): a
     uint8 zarr array over this task's block grid where 1 = skip the block
-    (pre-mark it done) and 0 = run it. Before the run, volara writes it into
-    daisy's tracking store as a caller-provided ``done`` array, so masked blocks
-    are skipped without ever being scheduled -- daisy still creates and tracks the
-    task and reports the skips in its summary. On a resume the mask is OR'd into
-    the existing done state, so real completions from a prior run are preserved.
+    (pre-mark it done) and 0 = run it. Before the run, volara seeds it into
+    daisy's tracking store, so masked blocks are skipped without ever being
+    scheduled; daisy still tracks the task and reports the skips in its summary.
 
-    The mask's shape must equal daisy's block-grid shape
-    (``ceil(total_roi.shape / block_size)`` over the context-grown total ROI);
-    daisy validates this on open and rejects a mismatch with a useful error. How
-    the mask is built is left to the caller (e.g. a slabreg helper that marks the
-    blocks far from a predicted surface).
+    Grid contract: the mask's shape must equal :attr:`block_grid_shape`
+    (``ceil(total_roi.shape / block)`` over the context-grown total ROI), and
+    cell ``i`` in dim ``d`` covers the write window starting at
+    ``block_grid_cell_origin()[d] + i * block[d]``. ⚠️ That origin is NOT
+    ``write_roi.offset``: daisy indexes a block against the CONTEXT-GROWN total
+    ROI, so the block written at ``write_roi.offset`` is cell
+    ``context_low // block``. Use :meth:`block_grid_slices` to map a world ROI to
+    cells rather than deriving the index yourself.
+
+    Resume contract: seeded skip bits are recorded separately from real
+    completions, so re-running with a different mask un-skips blocks the new
+    mask no longer covers while keeping every block a prior run actually
+    computed. A task whose geometry changed refuses to reuse the store.
+
+    Requires a daisy that accepts a caller-seeded tracking store
+    (funkelab/daisy ``a160769``, v2.0 branch, 2026-08-31); on an older daisy the
+    seed refuses up front, naming that commit.
     """
 
     def __hash__(self):
@@ -172,18 +254,87 @@ class BlockwiseTask(StrictBaseModel, ABC):
         """
         return self.meta_dir / "config.json"
 
-
     @property
     def tracking_path(self) -> "Path":
-        """Where daisy persists its built-in per-block tracking for this task.
+        """Where daisy persists its per-block tracking for this task.
 
-        Kept under ``meta_dir`` so ``drop()`` resets it with the logs; MUST agree
-        with the ``tracking_path=`` handed to ``daisy.Task`` in ``task()`` below.
-        (Restored 2026-08-24: this property was on the daisy-tracking branch and
-        was lost when the branch history was rewritten -- callers like
-        fullres_surface_skip read it to pre-mark skippable blocks.)
+        Kept under ``meta_dir`` so ``drop()`` resets it with the logs; ``task()``
+        hands exactly this path to ``daisy.Task(tracking_path=...)``.
         """
         return self.meta_dir / "blocks_done"
+
+    def _context_pair(self) -> tuple[Coordinate, Coordinate]:
+        """``(context_low, context_high)`` as ``task()`` resolves them."""
+        context = self.context_size
+        if not isinstance(context, Coordinate):
+            assert isinstance(context, tuple)
+            return context[0], context[1]
+        return context, context
+
+    @property
+    def block_grid_shape(self) -> tuple[int, ...]:
+        """Shape of daisy's per-block tracking grid for this task.
+
+        ``ceil(total_roi.shape / block)`` where ``total_roi`` is the
+        context-grown write ROI and ``block`` is ``block_write_roi.shape`` --
+        the same numbers ``task()`` hands to ``daisy.Task``.
+        """
+        lo, hi = self._context_pair()
+        total = self.write_roi.grow(lo, hi)
+        block = self.block_write_roi.shape
+        return tuple(-(-int(t) // int(b)) for t, b in zip(total.shape, block))
+
+    def block_grid_cell_origin(self) -> Coordinate:
+        """World coordinate that grid cell ``0`` starts at, per dim.
+
+        ⚠️ NOT ``write_roi.offset``. daisy indexes a block as
+        ``(block.write_roi.offset - total_roi.offset) // write_shape``
+        (``block_tracking.rs::grid_coord``), and volara hands it the
+        CONTEXT-GROWN write ROI as ``total_roi``. So the block whose write
+        window starts at ``write_roi.offset`` is cell ``context_low // block``,
+        not cell 0, and the grid origin sits ``(context_low // block) * block``
+        below the write offset -- floor-divided, because daisy's index is an
+        integer division and every block shifts by the same whole number of
+        cells.
+
+        Measured against daisy's own ``done`` array, write ROI ``(0,0)+(40,10)``
+        with ``block = (10, 10)`` (4 blocks at write offsets 0/10/20/30):
+
+        ==============  ======================  ===========================
+        ``context_low``  daisy ``done``          cell of the block at 0
+        ==============  ======================  ===========================
+        0               ``[1,1,1,1]``           0
+        9               ``[1,1,1,1,0,0]``       0
+        10              ``[0,1,1,1,1,0]``       1
+        25              ``[0,0,1,1,1,1,0,0,0]`` 2
+        ==============  ======================  ===========================
+        """
+        lo, _ = self._context_pair()
+        block = self.block_write_roi.shape
+        return Coordinate(
+            int(o) - (int(l) // int(b)) * int(b)
+            for o, l, b in zip(self.write_roi.offset, lo, block)
+        )
+
+    def block_grid_slices(self, roi: Roi) -> tuple[slice, ...]:
+        """Grid cells whose WRITE window intersects ``roi``, as per-dim slices.
+
+        Cell ``i`` in dim ``d`` covers the write window starting at
+        ``block_grid_cell_origin()[d] + i * block[d]`` -- see there for why that
+        is not ``write_roi.offset``. Slices are clipped to
+        :attr:`block_grid_shape`.
+        """
+        block = self.block_write_roi.shape
+        anchor = self.block_grid_cell_origin()
+        grid = self.block_grid_shape
+        out = []
+        for d, (a, b, g) in enumerate(zip(anchor, block, grid)):
+            begin = int(roi.begin[d]) - int(a)
+            end = int(roi.end[d]) - int(a)
+            lo = max(begin // int(b), 0)
+            hi = min(-(-end // int(b)), g)
+            out.append(slice(lo, max(hi, lo)))
+        return tuple(out)
 
     def process_roi(self, roi: Roi, context: Coordinate | None = None):
         """
@@ -326,8 +477,7 @@ class BlockwiseTask(StrictBaseModel, ABC):
                     with benchmark_logger.trace("Process Block"):
                         process_block(block)
 
-            if self.block_done_mask is not None:
-                self._seed_block_done_mask()
+            self._seed_block_done_mask()
 
             task = daisy.Task(
                 self.task_name,
@@ -338,7 +488,7 @@ class BlockwiseTask(StrictBaseModel, ABC):
                 read_write_conflict=self.read_write_conflict,
                 fit=self.fit,
                 max_workers=self.num_workers,
-                tracking_path=str(self.meta_dir / "blocks_done"),
+                tracking_path=str(self.tracking_path),
                 max_retries=2,
                 timeout=self.block_timeout,
                 upstream_tasks=(
@@ -354,44 +504,175 @@ class BlockwiseTask(StrictBaseModel, ABC):
 
             yield task
 
-    def _seed_block_done_mask(self) -> None:
-        """Write ``block_done_mask`` into daisy's tracking store as a
-        caller-provided ``done`` array, before the task runs.
+    def _seed_layout(self) -> dict:
+        """The task geometry a seeded tracking store is only valid for."""
+        lo, hi = self._context_pair()
+        total = self.write_roi.grow(lo, hi)
+        return {
+            "total_roi": [list(total.offset), list(total.shape)],
+            "read_roi": [
+                list(self.block_write_roi.grow(lo, hi).offset),
+                list(self.block_write_roi.grow(lo, hi).shape),
+            ],
+            "write_roi": [
+                list(self.block_write_roi.offset),
+                list(self.block_write_roi.shape),
+            ],
+            "fit": str(self.fit),
+            "grid_shape": list(self.block_grid_shape),
+        }
 
-        daisy accepts a hash-less tracking group and validates it by shape,
-        reading ``done`` as a raw uint8 single-chunk array -- so the mask is
-        written uncompressed at ``chunks == shape``; a compressed chunk would be
-        mmapped as garbage. On a resume the mask is OR'd into whatever daisy
-        already marked done, so real completions from a prior run are preserved.
-        A shape that does not match daisy's block grid is rejected by daisy on
-        open with an actionable error.
+    def _seed_block_done_mask(self) -> None:
+        """Reconcile ``block_done_mask`` with daisy's tracking store before the run.
+
+        ⚠️ Runs on EVERY task, including ``block_done_mask=None``. Seeding only
+        when a mask is present leaves the previous run's skip bits standing in
+        ``done``, and daisy honours them: the narrowest mask of all -- removing
+        the field -- would otherwise be the one case that never un-skips.
+        Measured before this was unconditional: a mask-less rerun through a
+        seeded meta dir logged ``resumed -- 1/4 blocks skipped via done markers``
+        and left the masked region unwritten with ``failed=0``. ``None`` is
+        therefore an all-zero mask, and a store carrying no seed record is left
+        untouched (so an unmasked task pays neither the probe nor a write).
+
+        Three bits of state keep "seeded" and "completed" apart:
+
+        ``done``
+            what daisy reads. Written ``real | skip``.
+        ``seed``
+            the bits THIS volara put in ``done`` that no worker earned, i.e.
+            ``skip & ~real``. Real completions are never recorded here, so a
+            widen-then-narrow cycle cannot demote one into a re-run.
+        ``_SEED_ATTR``
+            the layout the store was seeded for, plus the mask digest. A store
+            volara seeded never acquires daisy's own ``daisy_task_hash`` (volara
+            creates the group first, and daisy only stamps a group it creates),
+            so this attr is the ONLY layout identity such a store has -- which is
+            why it must be checked on every run, not only masked ones.
+
+        ⛔ The write order is a sandwich, and it is not decoration. The resume
+        invariant is ``done & ~seed == real``; every intermediate state must keep
+        ``seed`` a SUPERSET of ``done & ~real``, so an interruption can only cost
+        a recompute. Narrowing ``seed`` before ``done`` drops that -- measured: a
+        run masking cell 0, then a mask-less rerun killed in the window, leaves
+        ``done=[1,1,1,1] seed=[0,0,0,0]`` and cell 0 is a permanent completion no
+        worker ever ran, with ``failed=0``. Narrowing is exactly what this
+        feature is for (``block_done_mask=None`` is the narrowest mask of all),
+        so the widening write goes first, ``done`` in the middle, and the
+        tightening write last. It does not take a SIGKILL: an ENOSPC on the
+        ``done`` write leaves the same state, and the operator fixes the disk and
+        reruns into a silent skip.
         """
+        import hashlib
+
         import zarr
 
-        skip = (self.block_done_mask.read_mask() != 0).astype(np.uint8)
-        tracking = self.meta_dir / "blocks_done"
-        if (tracking / "done" / "zarr.json").exists():
-            done = zarr.open(str(tracking / "done"), mode="r+")
-            cur = np.asarray(done[:], dtype=np.uint8)
+        tracking = self.tracking_path
+        seeded = (tracking / "done" / "zarr.json").exists()
+        if seeded:
+            group = zarr.open_group(str(tracking), mode="r+")
+            prior = cast("dict | None", dict(group.attrs).get(_SEED_ATTR))
+        else:
+            group, prior = None, None
+        if self.block_done_mask is None and prior is None:
+            # Nothing volara seeded and nothing to seed: daisy owns this store.
+            return
+
+        _require_daisy_accepts_seeded_store()
+        expected = self.block_grid_shape
+        if self.block_done_mask is None:
+            skip = np.zeros(expected, dtype=np.uint8)
+        else:
+            skip = (self.block_done_mask.read_mask() != 0).astype(np.uint8)
+            if tuple(skip.shape) != tuple(expected):
+                raise ValueError(
+                    f"block_done_mask shape {tuple(skip.shape)} does not match task "
+                    f"{self.task_name!r}'s block grid {tuple(expected)} "
+                    "(= ceil(context-grown total / block); cell i covers the write "
+                    "window at block_grid_cell_origin() + i*block -- see "
+                    "block_grid_slices())."
+                )
+        layout = self._seed_layout()
+
+        if group is not None:
+            # Layout BEFORE shape: a changed geometry usually changes the grid
+            # shape too, and "your mask is the wrong shape" is the wrong story
+            # then -- doubly so on the mask-less path, where there is no mask to
+            # blame.
+            #
+            # ⚠️ Only for a store DAISY DOES NOT OWN. The stamp exists because a
+            # volara-seeded group never gets daisy's `daisy_task_hash` and is
+            # therefore accepted for any layout; where the hash IS present daisy
+            # validates the geometry itself and is the authority. Honouring our
+            # stamp there bricks the store: a masked run at the wrong geometry
+            # writes the stamp, daisy then refuses and nothing runs, and every
+            # later run of the ORIGINAL task refuses on our stale stamp -- with
+            # "drop the meta dir" as the only way out, discarding real
+            # completions after a mistake that computed nothing.
+            daisy_owned = "daisy_task_hash" in dict(group.attrs)
+            if prior is not None and not daisy_owned and prior.get("layout") != layout:
+                raise RuntimeError(
+                    f"task {self.task_name!r}: the seeded tracking store at "
+                    f"{tracking} was written for a different task geometry; "
+                    f"drop the meta dir ({self.meta_dir}) to reset tracking "
+                    "rather than reusing done bits from another layout."
+                )
+            cur = self._read_grid_array(group, "done")
             if cur.shape != skip.shape:
                 raise ValueError(
-                    f"block_done_mask shape {skip.shape} does not match the "
-                    f"existing done array shape {cur.shape} for task "
-                    f"{self.task_name!r}"
+                    f"task {self.task_name!r}: the existing done array has shape "
+                    f"{cur.shape} but this task's block grid is "
+                    f"{tuple(skip.shape)}; drop the meta dir to reset tracking."
                 )
-            done[:] = cur | skip
+            if prior is not None:
+                prev_seed = self._read_grid_array(group, "seed")
+                real = cur & ~prev_seed
+            else:
+                # daisy wrote this store; every bit in it was earned.
+                real = cur
         else:
             group = zarr.open_group(str(tracking), mode="a")
-            done = group.create_array(
-                "done",
-                shape=skip.shape,
-                chunks=skip.shape,
-                dtype="uint8",
-                fill_value=0,
-                compressors=[],
-                overwrite=True,
-            )
-            done[:] = skip
+            real = np.zeros_like(skip)
+
+        record = {
+            "layout": layout,
+            "mask_sha256": hashlib.sha256(skip.tobytes()).hexdigest(),
+        }
+        seeded_now = skip & ~real
+        prev = (
+            self._read_grid_array(group, "seed")
+            if "seed" in group
+            else np.zeros_like(skip)
+        )
+        # WIDEN -> stamp -> done -> TIGHTEN. Each prefix leaves `seed` covering
+        # every mask-only bit in `done`; see the docstring for what the other
+        # order costs. The stamp precedes `done` for the same reason: without it
+        # a fresh store's seeded bits read back as real.
+        self._write_grid_array(group, "seed", prev | seeded_now)
+        group.attrs[_SEED_ATTR] = record
+        self._write_grid_array(group, "done", real | skip)
+        self._write_grid_array(group, "seed", seeded_now)
+
+    @staticmethod
+    def _read_grid_array(group, name: str) -> "np.ndarray":
+        """``group[name]`` as a uint8 array. Narrowing lives here because
+        ``Group.__getitem__`` is typed ``AnyArray | Group``, so subscripting the
+        result is unchecked at every call site otherwise."""
+        arr = cast("Any", group[name])
+        return np.asarray(arr[:], dtype=np.uint8)
+
+    @staticmethod
+    def _write_grid_array(group, name: str, values: "np.ndarray") -> None:
+        """Write ``values`` to ``group[name]``, creating it in the raw
+        single-chunk uint8 layout daisy reads ``done`` as."""
+        if name in group:
+            cast("Any", group[name])[:] = values
+            return
+        arr = group.create_array(
+            name, shape=values.shape, chunks=values.shape, dtype="uint8",
+            fill_value=0, compressors=[], overwrite=True,
+        )
+        arr[:] = values
 
     def get_benchmark_logger(self) -> BenchmarkLogger:
         _benchmark_db_path = Path("volara_benchmark_logs/benchmark.db")

--- a/volara/blockwise/blockwise.py
+++ b/volara/blockwise/blockwise.py
@@ -16,6 +16,7 @@ from volara.logging import get_log_basedir, set_log_basedir
 from ..utils import PydanticRoi, StrictBaseModel
 from ..workers import Worker
 from .benchmark import BenchmarkLogger
+from ..datasets import MaskDataset
 
 if TYPE_CHECKING:
     from .pipeline import Pipeline
@@ -67,6 +68,23 @@ class BlockwiseTask(StrictBaseModel, ABC):
     single block legitimately runs long (e.g. the global mutex watershed) must set
     an explicit large value instead (see ``GraphMWS``). When a block exceeds the
     timeout daisy reclaims it and retries under ``max_retries``.
+    """
+
+    block_done_mask: MaskDataset | None = None
+    """
+    An optional per-block SKIP mask (a :class:`~volara.datasets.MaskDataset`): a
+    uint8 zarr array over this task's block grid where 1 = skip the block
+    (pre-mark it done) and 0 = run it. Before the run, volara writes it into
+    daisy's tracking store as a caller-provided ``done`` array, so masked blocks
+    are skipped without ever being scheduled -- daisy still creates and tracks the
+    task and reports the skips in its summary. On a resume the mask is OR'd into
+    the existing done state, so real completions from a prior run are preserved.
+
+    The mask's shape must equal daisy's block-grid shape
+    (``ceil(total_roi.shape / block_size)`` over the context-grown total ROI);
+    daisy validates this on open and rejects a mismatch with a useful error. How
+    the mask is built is left to the caller (e.g. a slabreg helper that marks the
+    blocks far from a predicted surface).
     """
 
     def __hash__(self):
@@ -308,6 +326,9 @@ class BlockwiseTask(StrictBaseModel, ABC):
                     with benchmark_logger.trace("Process Block"):
                         process_block(block)
 
+            if self.block_done_mask is not None:
+                self._seed_block_done_mask()
+
             task = daisy.Task(
                 self.task_name,
                 total_roi=self.write_roi.grow(context_low, context_high),
@@ -332,6 +353,45 @@ class BlockwiseTask(StrictBaseModel, ABC):
             )
 
             yield task
+
+    def _seed_block_done_mask(self) -> None:
+        """Write ``block_done_mask`` into daisy's tracking store as a
+        caller-provided ``done`` array, before the task runs.
+
+        daisy accepts a hash-less tracking group and validates it by shape,
+        reading ``done`` as a raw uint8 single-chunk array -- so the mask is
+        written uncompressed at ``chunks == shape``; a compressed chunk would be
+        mmapped as garbage. On a resume the mask is OR'd into whatever daisy
+        already marked done, so real completions from a prior run are preserved.
+        A shape that does not match daisy's block grid is rejected by daisy on
+        open with an actionable error.
+        """
+        import zarr
+
+        skip = (self.block_done_mask.read_mask() != 0).astype(np.uint8)
+        tracking = self.meta_dir / "blocks_done"
+        if (tracking / "done" / "zarr.json").exists():
+            done = zarr.open(str(tracking / "done"), mode="r+")
+            cur = np.asarray(done[:], dtype=np.uint8)
+            if cur.shape != skip.shape:
+                raise ValueError(
+                    f"block_done_mask shape {skip.shape} does not match the "
+                    f"existing done array shape {cur.shape} for task "
+                    f"{self.task_name!r}"
+                )
+            done[:] = cur | skip
+        else:
+            group = zarr.open_group(str(tracking), mode="a")
+            done = group.create_array(
+                "done",
+                shape=skip.shape,
+                chunks=skip.shape,
+                dtype="uint8",
+                fill_value=0,
+                compressors=[],
+                overwrite=True,
+            )
+            done[:] = skip
 
     def get_benchmark_logger(self) -> BenchmarkLogger:
         _benchmark_db_path = Path("volara_benchmark_logs/benchmark.db")

--- a/volara/blockwise/blockwise.py
+++ b/volara/blockwise/blockwise.py
@@ -155,6 +155,18 @@ class BlockwiseTask(StrictBaseModel, ABC):
         return self.meta_dir / "config.json"
 
 
+    @property
+    def tracking_path(self) -> "Path":
+        """Where daisy persists its built-in per-block tracking for this task.
+
+        Kept under ``meta_dir`` so ``drop()`` resets it with the logs; MUST agree
+        with the ``tracking_path=`` handed to ``daisy.Task`` in ``task()`` below.
+        (Restored 2026-08-24: this property was on the daisy-tracking branch and
+        was lost when the branch history was rewritten -- callers like
+        fullres_surface_skip read it to pre-mark skippable blocks.)
+        """
+        return self.meta_dir / "blocks_done"
+
     def process_roi(self, roi: Roi, context: Coordinate | None = None):
         """
         A helper function to process a given roi without needing to start a

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -400,6 +400,39 @@ class Labels(Dataset):
         return {}
 
 
+class MaskDataset(Dataset):
+    """A per-block SKIP mask for a blockwise task.
+
+    Points to a zarr array in the task's BLOCK-GRID space -- one element per
+    *block*, not per voxel: dtype uint8, shape equal to daisy's block-grid shape
+    (``ceil(total_roi.shape / block_size)`` over the context-grown total ROI),
+    value 1 = skip this block (pre-mark it done), 0 = run it.
+
+    Handed to ``BlockwiseTask.block_done_mask``, volara writes it into daisy's
+    tracking store as a *caller-provided* ``done`` array (daisy accepts a
+    hash-less tracking group and validates it by shape), so the masked blocks
+    are skipped without ever running. This is the generic form of the
+    surface-band skip: a thin predicted surface only touches a few blocks, so the
+    rest can be pre-skipped.
+
+    Grid-space, not voxel-space: the inherited voxel-metadata fields are unused.
+    How the mask is built is left to the caller (e.g. a slabreg helper that marks
+    the blocks whose Z range cannot reach a predicted surface).
+    """
+
+    dataset_type: Literal["mask"] = "mask"
+
+    @property
+    def attrs(self):
+        return {}
+
+    def read_mask(self) -> "np.ndarray":
+        """The mask as a uint8 numpy array in block-grid space (1 = skip)."""
+        import zarr
+
+        return np.asarray(zarr.open(str(self.store), mode="r")[:], dtype=np.uint8)
+
+
 class CloudVolumeWrapper(Dataset):
     """
     Represents a volumetric dataset through Cloud Volume.

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -404,20 +404,19 @@ class MaskDataset(Dataset):
     """A per-block SKIP mask for a blockwise task.
 
     Points to a zarr array in the task's BLOCK-GRID space -- one element per
-    *block*, not per voxel: dtype uint8, shape equal to daisy's block-grid shape
-    (``ceil(total_roi.shape / block_size)`` over the context-grown total ROI),
-    value 1 = skip this block (pre-mark it done), 0 = run it.
+    *block*, not per voxel: dtype uint8, shape equal to the task's
+    ``block_grid_shape`` (``ceil(total_roi.shape / block)`` over the
+    context-grown total ROI), value 1 = skip this block (pre-mark it done),
+    0 = run it. Cell ``i`` in dim ``d`` covers the write window starting at
+    ``block_grid_cell_origin()[d] + i * block[d]`` -- which is BELOW
+    ``write_roi.offset`` whenever ``context_low >= block``, because daisy indexes
+    blocks against the context-grown total ROI. Build masks with
+    ``BlockwiseTask.block_grid_slices`` rather than deriving cell indices.
 
-    Handed to ``BlockwiseTask.block_done_mask``, volara writes it into daisy's
-    tracking store as a *caller-provided* ``done`` array (daisy accepts a
-    hash-less tracking group and validates it by shape), so the masked blocks
-    are skipped without ever running. This is the generic form of the
-    surface-band skip: a thin predicted surface only touches a few blocks, so the
-    rest can be pre-skipped.
+    Handed to ``BlockwiseTask.block_done_mask``, volara seeds it into daisy's
+    tracking store so the masked blocks are skipped without ever running.
 
     Grid-space, not voxel-space: the inherited voxel-metadata fields are unused.
-    How the mask is built is left to the caller (e.g. a slabreg helper that marks
-    the blocks whose Z range cannot reach a predicted surface).
     """
 
     dataset_type: Literal["mask"] = "mask"


### PR DESCRIPTION
`block_done_mask`: skip blocks a caller has pre-marked done, via a `MaskDataset` seeded into
daisy's tracking store. Your `skip-blocks-mask` work (`260d4d4`, `90505db`, unchanged and still
yours), plus two commits making the seeding safe to resume.

Fast-forward from `will/rbws-plus-main`. Your branch is untouched at `2445071`.

> **On the badge:** #70 shows MERGED but its code is on no branch. That merge was made in error by
> an automation session without merge authority and undone at Jeff's direction — this PR is the
> "request it" path that correction comment names. **You own the landing call.** The unrelated
> `Dataset.drop()` change #70's body flagged is split out as #73.

## What it does

`BlockwiseTask.block_done_mask` takes a uint8 array over the task's block grid, 1 = skip. Before
the run volara writes those bits into daisy's `done` array, so masked blocks are never scheduled.
Callers build the mask with `block_grid_slices(roi)`.

The whole difficulty is that `done` then holds two kinds of bit — what a worker earned and what
volara asserted — and daisy cannot tell them apart. So the store carries three things:

| | |
|---|---|
| `done` | what daisy reads. `real \| skip` |
| `seed` | the bits volara put there that nobody earned: `skip & ~real` |
| `volara_block_done_seed` attr | the layout the store was seeded for, plus the mask digest |

`real = done & ~seed` on every resume, which is what makes a **narrower mask un-skip** what it no
longer covers while keeping every block that actually ran.

The write order is a sandwich — **widen `seed` → stamp → `done` → tighten `seed`** — because every
intermediate state has to keep `seed` a superset of `done & ~real`. Narrowing first breaks that in
the one direction the feature exists for: mask a cell, drop the mask, interrupt any of the writes,
and the store settles at `done=[1,1,1,1] seed=[0,0,0,0]` with that cell a permanent completion no
worker ever ran and `failed=0`. It doesn't take a SIGKILL — an ENOSPC on the `done` write leaves the
same state, so you free space, rerun, and get the silent skip.

Three consequences worth knowing:

- **Reconciliation runs on every task, including `block_done_mask=None`.** Dropping the field is
  the narrowest mask of all, and if seeding only happened when a mask was present it would be the
  one case that never un-skips — a trial run with a mask, then a production run without one
  through the same meta dir, schedules zero blocks over the masked region and reports `failed=0`.
  A store with no seed record returns early, so an unmasked task pays neither the probe nor a
  write.
- **The grid is anchored where daisy anchors it.** daisy indexes a block as
  `(write_roi.offset - total_roi.offset) // write_shape`, and volara passes the *context-grown*
  ROI as `total_roi`, so the block written at `write_roi.offset` is cell `context_low // block` —
  not cell 0. `block_grid_cell_origin()` is the single spelling of that. Measured against daisy's
  own `done` array (write ROI `(0,0)+(40,10)`, block `10x10`):

  | `context_low` | daisy `done` | cell of the block at 0 |
  |---|---|---|
  | 0 | `[1,1,1,1]` | 0 |
  | 9 | `[1,1,1,1,0,0]` | 0 |
  | 10 | `[0,1,1,1,1,0]` | 1 |
  | 25 | `[0,0,1,1,1,1,0,0,0]` | 2 |

  It only bites at `context >= block`, which no predict-style task hits today — but
  volara-surface#41 builds its mask from the grown total, so this is the half that had to move.
- **The layout stamp is the only identity a *hash-less* store has.** volara creates the group, so
  daisy never writes its `daisy_task_hash`, and a hash-less group is accepted for any layout. The
  stamp is checked on every run of such a store, before the shape check. Where daisy's hash *is*
  present daisy validates the geometry itself and is the authority — honouring our stamp there
  bricks the store, since a masked run at the wrong geometry writes the stamp, daisy refuses and
  runs nothing, and every later run of the original task then refuses on a stale stamp.

## Requires daisy `a160769`

`_require_daisy_accepts_seeded_store()` seeds a one-cell store in the production format and runs a
one-block task through it — measured rather than compared against a version string. An older daisy
refuses at scheduler init and the error names the commit. Memoised per process, `multiprocessing=
False`, ~0.08 s. `pyproject.toml` pins it. (volara has no `uv.lock` — it is gitignored.)

⚠️ This pins **every** volara user to that daisy rev, not only mask users.

## Verification

Suite on daisy `a160769`: **5 failed, 225 passed**. The 5 are pre-existing — four are this repo's
standing failures (`test_init_block_array`, `test_check_block_func`,
`test_pipeline_drop_outputs_false`, `test_threshold_drop_outputs_false_keeps_output`, all red on
`will/rbws-plus-main` itself) and `test_lambda_task_multiprocessing_local_worker` fails identically
on the base here. `ruff check` clean.

The **`ty` job is red on `will/rbws-plus-main` itself** (72 whole-tree diagnostics) and on #73,
which barely touches anything — it is not a gate this PR can turn green. What this PR does to it:
`blockwise.py` goes **14 → 8** (base is 5; the 3 over it are `unknown-argument` against daisy's
Rust-backed `Task`/`run_blockwise`, the same class the base already carries), and the new test file
contributes 17. Net across the two files, **28 → 25**.

16 tests in `tests/test_block_done_mask.py` count **real block-body invocations** through daisy
(the body runs in workers, so an in-process counter would count nothing). Each test that pins a
resume behaviour was verified to fail without its fix — including the ordering one, which
interrupts each of the three writes in turn and requires the mask-skipped cell to come back. That
guard used to be an `inspect.getsource` index comparison, which passed on the bug and on the fix
alike.

`blockwise.py` is deliberately left ruff-format-unclean: so is the base, and reformatting would
bury the change. CI runs `ruff check` only.

## Downstream

`MaskDataset` / `block_done_mask` are what volara-surface#41 calls; that in turn is what
slabreg#166's `surface.fullres_surface_skip` needs. ⛔ **Order matters:** volara-surface#41 imports
`MaskDataset` at module level, so landing it before this PR breaks `volara_surface.blockwise
.extract` at import — s01 dies rather than degrades. This one goes first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
