### PR TITLE
datasets: Dataset.drop treats a local str store as a local path, refuses other URLs loudly

### DIFF
--- a/tests/test_dataset_drop.py
+++ b/tests/test_dataset_drop.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import pytest
+
+from volara.datasets import Raw
+
+
+def _store(tmp_path) -> Path:
+    p = tmp_path / "x.zarr"
+    p.mkdir()
+    (p / "zarr.json").write_text("{}")
+    return p
+
+
+def test_drop_removes_a_path_store(tmp_path):
+    p = _store(tmp_path)
+    Raw(store=p).drop()
+    assert not p.exists()
+
+
+def test_drop_removes_a_local_str_store(tmp_path):
+    p = _store(tmp_path)
+    Raw(store=str(p)).drop()
+    assert not p.exists()
+
+
+def test_drop_of_a_missing_local_store_is_a_noop(tmp_path):
+    Raw(store=str(tmp_path / "never-created.zarr")).drop()
+
+
+def test_drop_refuses_a_non_s3_url_rather_than_silently_skipping(tmp_path):
+    with pytest.raises(ValueError, match="URL this method cannot delete"):
+        Raw(store="gs://bucket/x.zarr").drop()

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -152,21 +152,33 @@ class Dataset(StrictBaseModel, ABC):
     def drop(self) -> None:
         """
         Delete this dataset.
+
+        A LOCAL PATH GIVEN AS A str IS STILL A LOCAL PATH. ``store`` is typed
+        ``Path | str``, so a caller that builds one from string formatting (slabreg's
+        s11 does, for the affs and heatmap stores) passes validation and then hits
+        "not a Path or s3 path" only at drop time -- reached from ``ctx.rerun`` ->
+        ``task.drop()``, i.e. exactly the recompute path invoked when a store's
+        geometry no longer matches. Coerce instead of refusing; s3:// keeps its own
+        branch below. (Reapplied 2026-08-20: the original fix was lost uncommitted.)
         """
-        if not isinstance(self.store, Path):
-            if isinstance(self.store, str) and self.store.startswith("s3://"):
+        if isinstance(self.store, str) and not self.store.startswith("s3://"):
+            store: Path | str = Path(self.store)
+        else:
+            store = self.store
+        if not isinstance(store, Path):
+            if isinstance(store, str) and store.startswith("s3://"):
                 # drop an s3 zarr
                 fs = self._s3fs()
                 try:
-                    fs.rm(self.store, recursive=True)
+                    fs.rm(store, recursive=True)
                 except FileNotFoundError:
                     pass
             else:
                 raise ValueError(
-                    f"Not dropping dataset: store {self.store} is not a Path or s3 path"
+                    f"Not dropping dataset: store {store} is not a Path or s3 path"
                 )
-        elif self.store.exists():
-            rmtree(self.store)
+        elif store.exists():
+            rmtree(store)
 
     def spoof(self, spoof_dir: Path):
         if not isinstance(self.store, Path):

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -150,34 +150,29 @@ class Dataset(StrictBaseModel, ABC):
             return self.store.rstrip("/").split("/")[-1]
 
     def drop(self) -> None:
-        """
-        Delete this dataset.
-
-        A LOCAL PATH GIVEN AS A str IS STILL A LOCAL PATH. ``store`` is typed
-        ``Path | str``, so a caller that builds one from string formatting (slabreg's
-        s11 does, for the affs and heatmap stores) passes validation and then hits
-        "not a Path or s3 path" only at drop time -- reached from ``ctx.rerun`` ->
-        ``task.drop()``, i.e. exactly the recompute path invoked when a store's
-        geometry no longer matches. Coerce instead of refusing; s3:// keeps its own
-        branch below. (Reapplied 2026-08-20: the original fix was lost uncommitted.)
-        """
-        if isinstance(self.store, str) and not self.store.startswith("s3://"):
-            store: Path | str = Path(self.store)
-        else:
-            store = self.store
-        if not isinstance(store, Path):
-            if isinstance(store, str) and store.startswith("s3://"):
-                # drop an s3 zarr
-                fs = self._s3fs()
-                try:
-                    fs.rm(store, recursive=True)
-                except FileNotFoundError:
-                    pass
-            else:
+        """Delete this dataset's store: a local path (``Path`` or ``str``) or ``s3://``."""
+        store = self.store
+        if isinstance(store, str) and store.startswith("s3://"):
+            fs = self._s3fs()
+            try:
+                fs.rm(store, recursive=True)
+            except FileNotFoundError:
+                pass
+            return
+        if isinstance(store, str):
+            if "://" in store:
+                # any other URL scheme would silently coerce to a Path that never
+                # exists -- a no-op drop that looks like success
                 raise ValueError(
-                    f"Not dropping dataset: store {store} is not a Path or s3 path"
+                    f"Not dropping dataset: store {store} is a URL this method "
+                    "cannot delete (only local paths and s3:// are supported)"
                 )
-        elif store.exists():
+            store = Path(store)  # a local path given as a str is still a local path
+        if not isinstance(store, Path):
+            raise ValueError(
+                f"Not dropping dataset: store {store} is not a Path or s3 path"
+            )
+        if store.exists():
             rmtree(store)
 
     def spoof(self, spoof_dir: Path):


### PR DESCRIPTION
`Dataset.drop()` treats a local `str` store as a local path, and refuses other URLs loudly instead
of silently doing nothing.

Your `79024f4` (unchanged, still yours) plus a commit adding the refusal and
`tests/test_dataset_drop.py`. Fast-forward from `will/rbws-plus-main`; 2 files, +55/−15.

> **On the badge:** #71 shows MERGED but its code is on no branch — its head branch was deleted on
> merge and the merge was undone at Jeff's direction along with #70's, because the merge was made
> by an automation session without merge authority. See
> [#70's state note](https://github.com/e11bio/volara/pull/70#issuecomment-5504577236).

This is the split #70's body asked for (*"There is 1 unrelated change in here"*), so the `drop()`
fix travels on its own rather than riding the block-done-mask work in #72. The two touch disjoint
regions of `volara/datasets.py` — `drop()` here, the new `MaskDataset` there — so they do not
conflict and either can land first.

The 4 red checks are this repo's standing failures; they are red on `will/rbws-plus-main` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
