### PR TITLE
fix(datasets): drop() a local store given as a str

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ keywords = []
 requires-python = ">=3.11"
 
 dependencies = [
+    "universal-pathlib",
     "click>=8.0",
     # daisy v2 (Rust rewrite) -- pinned to the git v2.0 branch via
     # [tool.uv.sources] below until 2.0.0 is published to PyPI.

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -227,3 +227,18 @@ def test_attrs_labels_lsd():
 
     lsd = LSD(store="dummy")
     assert lsd.attrs == {"lsds": True}
+
+
+def test_drop_removes_a_local_store_given_as_a_str(tmp_path):
+    """``store`` is annotated ``Path | str``; both must drop.
+
+    A local path arriving as a ``str`` used to raise "not a Path or s3 path", so callers that
+    build ``Raw(store=str(...))`` -- the common case when a path is composed from a URI-aware
+    library -- could never delete a dataset.
+    """
+    for store in (tmp_path / "as_path.zarr", str(tmp_path / "as_str.zarr")):
+        arr = zarr.create_array(str(store), shape=(4, 4), chunks=(2, 2), dtype="uint8")
+        arr[:] = 1
+        assert Path(str(store)).exists()
+        Raw(store=store).drop()
+        assert not Path(str(store)).exists()

--- a/volara/datasets.py
+++ b/volara/datasets.py
@@ -10,6 +10,7 @@ from cloudvolume import CloudVolume
 from funlib.geometry import Coordinate
 from funlib.persistence import Array, open_ds, prepare_ds
 from pydantic import Field
+from upath import UPath
 
 from .ops import (
     OmeNormalize,
@@ -152,21 +153,19 @@ class Dataset(StrictBaseModel, ABC):
     def drop(self) -> None:
         """
         Delete this dataset.
+
+        ``store`` is resolved through :class:`upath.UPath`, so a local path and an ``s3://`` URI
+        are handled the same whether either arrives as a ``str`` or as a path object.
         """
-        if not isinstance(self.store, Path):
-            if isinstance(self.store, str) and self.store.startswith("s3://"):
-                # drop an s3 zarr
-                fs = self._s3fs()
-                try:
-                    fs.rm(self.store, recursive=True)
-                except FileNotFoundError:
-                    pass
-            else:
-                raise ValueError(
-                    f"Not dropping dataset: store {self.store} is not a Path or s3 path"
-                )
-        elif self.store.exists():
-            rmtree(self.store)
+        store = UPath(self.store)
+        if store.protocol in ("s3", "s3a"):
+            fs = self._s3fs()
+            try:
+                fs.rm(str(store), recursive=True)
+            except FileNotFoundError:
+                pass
+        elif store.exists():
+            rmtree(store)
 
     def spoof(self, spoof_dir: Path):
         if not isinstance(self.store, Path):


### PR DESCRIPTION
### The bug

`Dataset.store` is annotated `Path | str`, but `drop()` only handled a `Path` or an `s3://` string:

```python
if not isinstance(self.store, Path):
    if isinstance(self.store, str) and self.store.startswith("s3://"):
        ...
    else:
        raise ValueError(f"Not dropping dataset: store {self.store} is not a Path or s3 path")
```

A **local path arriving as a `str`** — which the annotation allows — hits the `else` and raises, so that dataset can never be deleted.

### How we hit it

slabreg builds `Raw(store=str(ctx.registration / "combined_volume"))`. The `str()` throws away a `UPath`, and s07's `--rerun` path then cannot clear the previous render:

```
ValueError: Not dropping dataset: store /…/registration.zarr/combined_volume is not a Path or s3 path
```

That's our `str()` to remove, but the annotation says a `str` store is legal, so `drop()` should honour it.

### The fix

Resolve `store` through `upath.UPath`, so local and `s3://` are handled the same whether either arrives as a `str` or a path object:

```python
store = UPath(self.store)
if store.protocol in ("s3", "s3a"):
    fs = self._s3fs()
    try:
        fs.rm(str(store), recursive=True)
    except FileNotFoundError:
        pass
elif store.exists():
    rmtree(store)
```

Behaviour per input, before → after:

| `store` | before | after |
|---|---|---|
| `Path` local | removed | removed |
| `str` local | **ValueError** | removed |
| `str` `s3://` | removed via `_s3fs()` | removed via `_s3fs()` |
| `UPath` s3 (`S3Path`) | **ValueError** | removed via `_s3fs()` |

That last row is why `UPath` rather than just coercing to `Path`: an `S3Path` is **not** a `pathlib.Path`, so `isinstance(store, Path)` rejects it, and `pathlib.Path("s3://…")` would mangle the URI. `_s3fs()` is still used for the s3 branch, so `s3_kwargs` (custom endpoint/credentials) keep applying.

### Scope

- `volara/datasets.py` — `drop()` only. `spoof()` and `name` keep their existing `isinstance(Path)` behaviour; happy to fold them in if you'd rather, but I kept this to the reported bug.
- `pyproject.toml` — adds `universal-pathlib`.
- `tests/test_dataset.py` — one regression test. Verified it **fails** on the current code and passes with the change.

`tests/test_logging.py` has 3 failures on this branch tip both with and without this change — pre-existing, untouched here.